### PR TITLE
Improve Budget Tool CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ python3 budget_tool.py balance <category> [--user NAME]
 python3 budget_tool.py totals [--user NAME]            # show overall totals
 python3 budget_tool.py list                            # list all categories
 python3 budget_tool.py history [CATEGORY] [--user NAME] [--limit N]
+python3 budget_tool.py --db mydata.db totals          # use a custom database
 ```
 
-The database file `budget.db` is created in the same directory as the script.
+By default the database file `budget.db` is created in the same directory as the
+script. Set the `--db` option or the `BUDGET_DB` environment variable to use a
+different location.
 
 ## Running tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "budget-tool"
+version = "0.1.0"
+description = "CLI-based budgeting tool"
+authors = [{name="Budget Maintainer", email="maintainer@example.com"}]
+readme = "README.md"
+license = {text = "MIT"}
+
+[project.scripts]
+budget-tool = "budget_tool:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flake8
+pylint
+pytest

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -6,11 +6,15 @@ from pathlib import Path
 SCRIPT = Path(__file__).resolve().parents[1] / "budget_tool.py"
 
 
-def run_cli(tmp_path, *args):
+def run_cli(tmp_path, *args, db_path=None):
     script_copy = tmp_path / "budget_tool.py"
     script_copy.write_bytes(SCRIPT.read_bytes())
+    cmd = ["python3", str(script_copy)]
+    if db_path:
+        cmd += ["--db", str(db_path)]
+    cmd.extend(args)
     result = subprocess.run(
-        ["python3", str(script_copy), *args],
+        cmd,
         cwd=tmp_path,
         text=True,
         capture_output=True,
@@ -57,3 +61,37 @@ def test_totals_output(tmp_path):
     assert "Total Income: 1500.00" in totals
     assert "Total Expense: 500.00" in totals
     assert "Net Balance: 1000.00" in totals
+
+
+def test_goal_warning(tmp_path):
+    run_cli(tmp_path, "init")
+    run_cli(tmp_path, "add-category", "Food")
+    run_cli(tmp_path, "set-goal", "Food", "50")
+    warn = run_cli(tmp_path, "add-expense", "Food", "60").stdout
+    assert "Warning" in warn
+
+
+def test_export_csv(tmp_path):
+    run_cli(tmp_path, "init")
+    run_cli(tmp_path, "add-category", "Job")
+    run_cli(tmp_path, "add-income", "Job", "100")
+    out = tmp_path / "data.csv"
+    run_cli(tmp_path, "export-csv", "--output", str(out))
+    assert out.exists()
+    lines = out.read_text().splitlines()
+    assert lines[0].startswith("category")
+    assert len(lines) == 2
+
+
+def test_history_output(tmp_path):
+    run_cli(tmp_path, "init")
+    run_cli(tmp_path, "add-category", "Misc")
+    run_cli(tmp_path, "add-expense", "Misc", "5", "-d", "snack")
+    hist = run_cli(tmp_path, "history").stdout
+    assert "snack" in hist
+
+
+def test_custom_db_path(tmp_path):
+    custom = tmp_path / "custom.db"
+    run_cli(tmp_path, "init", db_path=custom)
+    assert custom.exists()


### PR DESCRIPTION
## Summary
- add docstrings and line-wrapping fixes
- allow specifying DB path with `--db` or `BUDGET_DB`
- export CSV with utf-8 encoding
- add packaging metadata and requirements list
- extend test suite for goals, export, history and custom db path

## Testing
- `flake8`
- `pylint budget_tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684523d4c3648329a9c7dc080b90cda4