### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ Install `pytest` and run the test suite:
 pip install pytest
 pytest
 ```
+
+## Web Interface
+
+A simple Flask web interface is provided for easier interaction. Install the requirements and run:
+
+```bash
+pip install -r requirements.txt
+python3 webapp.py
+```
+
+This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories and add transactions using a basic Bootstrap UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,4 @@ license = {text = "MIT"}
 
 [project.scripts]
 budget-tool = "budget_tool:main"
+budget-web = "webapp:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flake8
 pylint
 pytest
 firebase-admin
+
+Flask

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Transaction History</title>
+</head>
+<body>
+<div class="container mt-4">
+  <h1>Transaction History</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Category</th>
+        <th>Type</th>
+        <th>Amount</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for row in rows %}
+      <tr>
+        <td>{{ row['created_at'] }}</td>
+        <td>{{ row['name'] }}</td>
+        <td>{{ row['type'] }}</td>
+        <td>{{ row['amount'] }}</td>
+        <td>{{ row['description'] or '' }}</td>
+      </tr>
+    {% else %}
+      <tr><td colspan="5">No transactions</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('index') }}">Back to Home</a>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <title>Budget Tool</title>
+</head>
+<body>
+<div class="container mt-4">
+  <h1>Budget Tool</h1>
+  <h2>Totals</h2>
+  <ul>
+    <li>Income: {{ income|round(2) }}</li>
+    <li>Expense: {{ expense|round(2) }}</li>
+    <li>Net Balance: {{ net|round(2) }}</li>
+  </ul>
+
+  <h2>Categories</h2>
+  <ul>
+  {% for cat in categories %}
+    <li>{{ cat }}</li>
+  {% else %}
+    <li>No categories</li>
+  {% endfor %}
+  </ul>
+
+  <h3>Add Category</h3>
+  <form method="post" action="{{ url_for('add_category_route') }}" class="row g-2">
+    <div class="col-auto">
+      <input class="form-control" name="name" placeholder="Category name">
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-primary">Add</button>
+    </div>
+  </form>
+
+  <h3 class="mt-4">Add Transaction</h3>
+  <form method="post" action="{{ url_for('add_transaction_route') }}" class="row gy-2 gx-3">
+    <div class="col-md-3">
+      <select class="form-select" name="category">
+        {% for cat in categories %}
+        <option value="{{ cat }}">{{ cat }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-2">
+      <input type="number" step="0.01" name="amount" class="form-control" placeholder="Amount">
+    </div>
+    <div class="col-md-2">
+      <select class="form-select" name="type">
+        <option value="income">Income</option>
+        <option value="expense">Expense</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <input name="description" class="form-control" placeholder="Description">
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-success">Add</button>
+    </div>
+  </form>
+
+  <p class="mt-4">
+    <a href="{{ url_for('history') }}">View History</a>
+  </p>
+</div>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,90 @@
+import budget_tool
+from flask import Flask, render_template, request, redirect, url_for
+
+app = Flask(__name__)
+
+@app.before_first_request
+def setup_db():
+    budget_tool.init_db()
+
+
+def get_categories():
+    conn = budget_tool.get_connection()
+    cur = conn.execute("SELECT name FROM categories ORDER BY name")
+    categories = [row[0] for row in cur.fetchall()]
+    conn.close()
+    return categories
+
+
+def get_totals(user: str = "default"):
+    conn = budget_tool.get_connection()
+    user_id = budget_tool.get_user_id(conn, user)
+    cur = conn.execute(
+        "SELECT type, SUM(amount) FROM transactions WHERE user_id=? GROUP BY type",
+        (user_id,),
+    )
+    totals = {row[0]: row[1] or 0 for row in cur.fetchall()}
+    conn.close()
+    income = totals.get("income", 0)
+    expense = totals.get("expense", 0)
+    return income, expense, income - expense
+
+
+def get_history(limit: int = 50, user: str = "default"):
+    conn = budget_tool.get_connection()
+    user_id = budget_tool.get_user_id(conn, user)
+    cur = conn.execute(
+        """
+        SELECT c.name, t.amount, t.type, t.description, t.created_at
+        FROM transactions t
+        JOIN categories c ON t.category_id = c.id
+        WHERE t.user_id = ?
+        ORDER BY t.created_at DESC
+        LIMIT ?
+        """,
+        (user_id, limit),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+@app.route("/")
+def index():
+    cats = get_categories()
+    income, expense, net = get_totals()
+    return render_template(
+        "index.html", categories=cats, income=income, expense=expense, net=net
+    )
+
+
+@app.route("/add-category", methods=["POST"])
+def add_category_route():
+    name = request.form.get("name")
+    if name:
+        budget_tool.add_category(name)
+    return redirect(url_for("index"))
+
+
+@app.route("/add-transaction", methods=["POST"])
+def add_transaction_route():
+    category = request.form["category"]
+    amount = request.form.get("amount", type=float)
+    ttype = request.form["type"]
+    desc = request.form.get("description") or None
+    budget_tool.add_transaction(category, amount, ttype, desc)
+    return redirect(url_for("index"))
+
+
+@app.route("/history")
+def history():
+    rows = get_history()
+    return render_template("history.html", rows=rows)
+
+
+def main():
+    app.run(debug=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include Flask dependency
- update pyproject with `budget-web` entry point
- add minimal Flask app to provide a web interface
- provide Bootstrap templates for home and history pages
- document the web interface in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452c8411c88329a286de28d5ba4ad0