### PR TITLE
Fix Flask 3 compatibility

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -3,8 +3,8 @@ from flask import Flask, render_template, request, redirect, url_for
 
 app = Flask(__name__)
 
-@app.before_first_request
-def setup_db():
+def setup_db() -> None:
+    """Initialize the database tables if they do not exist."""
     budget_tool.init_db()
 
 
@@ -83,6 +83,7 @@ def history():
 
 
 def main():
+    setup_db()
     app.run(debug=True)
 
 


### PR DESCRIPTION
## Summary
- initialize database on startup instead of using removed `before_first_request` hook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452fb1c3408329a6353a1709df34a2