### PR TITLE
Fix account deletion bug in web interface

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import budget_tool
+import webapp
+
+
+def setup_app(tmp_path):
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    webapp.setup_db()
+    return webapp.app.test_client()
+
+
+def get_account_names(conn):
+    cur = conn.execute("SELECT name FROM accounts ORDER BY name")
+    return [r[0] for r in cur.fetchall()]
+
+
+def test_update_accounts_delete(tmp_path):
+    client = setup_app(tmp_path)
+    # Add two accounts
+    budget_tool.set_account("A1", 100, 10, "Bank")
+    budget_tool.set_account("A2", 200, 20, "Bank")
+
+    # Build form data mimicking the edit table
+    data = {
+        "delete": "A1",
+        "old_0": "A1",
+        "name_0": "A1",
+        "balance_0": "100",
+        "payment_0": "10",
+        "type_0": "Bank",
+        "old_1": "A2",
+        "name_1": "A2",
+        "balance_1": "200",
+        "payment_1": "20",
+        "type_1": "Bank",
+    }
+    client.post("/update-accounts", data=data)
+
+    conn = budget_tool.get_connection()
+    names = get_account_names(conn)
+    conn.close()
+    assert names == ["A2"]
+

--- a/webapp.py
+++ b/webapp.py
@@ -147,6 +147,10 @@ def update_accounts_route():
         old = request.form.get(f"old_{i}")
         if old is None:
             break
+        # Skip rows marked for deletion to avoid recreating them
+        if old in deletes:
+            i += 1
+            continue
         name = request.form.get(f"name_{i}")
         balance = request.form.get(f"balance_{i}", type=float)
         payment = request.form.get(f"payment_{i}", type=float, default=0.0)


### PR DESCRIPTION
## Summary
- skip updating accounts in `/update-accounts` when they are flagged for deletion
- add regression test for account deletion via web interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454387dff48329a8742957fcfb5b5e