### PR TITLE
Implement bank balance forecast and APR fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ python3 budget_tool.py delete-category <name>          # remove a category
 python3 budget_tool.py set-account <name> <balance> [--payment AMT]
 python3 budget_tool.py delete-account <name>           # remove an account
 python3 budget_tool.py list-accounts                   # show account balances
+python3 budget_tool.py bank-balance <months>           # forecast bank balance
 python3 budget_tool.py history [CATEGORY] [--user NAME] [--limit N]
 python3 budget_tool.py --db mydata.db totals          # use a custom database
 ```


### PR DESCRIPTION
## Summary
- handle credit card APR more accurately with math.ceil rounding
- add helper functions to calculate totals and forecast bank balance
- warn when bank account will go negative
- support `bank-balance` CLI command for forecasting
- document new command
- test new behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845455edd00832982c66bf7733a532c