### PR TITLE
Add APR CLI option for account payoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ python3 budget_tool.py totals [--user NAME]            # show overall totals
 python3 budget_tool.py list                            # list all categories
 python3 budget_tool.py delete-category <name>          # remove a category
 python3 budget_tool.py set-account <name> <balance> [--payment AMT]
+                             [--type TYPE] [--apr RATE]
+                             [--escrow AMT] [--insurance AMT]
+                             [--tax AMT]
 python3 budget_tool.py delete-account <name>           # remove an account
 python3 budget_tool.py list-accounts                   # show account balances
 python3 budget_tool.py bank-balance <months>           # forecast bank balance

--- a/budget_tool.py
+++ b/budget_tool.py
@@ -628,6 +628,13 @@ def parse_args() -> argparse.Namespace:
     parser_acc.add_argument("name")
     parser_acc.add_argument("balance", type=float)
     parser_acc.add_argument("--payment", type=float, default=0.0)
+    parser_acc.add_argument("--type", default="Other", help="Account type")
+    parser_acc.add_argument("--apr", type=float, default=0.0, help="APR percent")
+    parser_acc.add_argument("--escrow", type=float, default=0.0, help="Escrow")
+    parser_acc.add_argument(
+        "--insurance", type=float, default=0.0, help="Home/auto insurance"
+    )
+    parser_acc.add_argument("--tax", type=float, default=0.0, help="Property tax")
 
     parser_del_acc = subparsers.add_parser(
         "delete-account", help="Delete an account"
@@ -702,7 +709,16 @@ def main() -> None:
         list_transactions(args.category, args.limit, args.user)
     elif args.command == "set-account":
         init_db()
-        set_account(args.name, args.balance, args.payment)
+        set_account(
+            args.name,
+            args.balance,
+            args.payment,
+            args.type,
+            args.apr,
+            args.escrow,
+            args.insurance,
+            args.tax,
+        )
     elif args.command == "list-accounts":
         init_db()
         list_accounts()

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -146,3 +146,25 @@ def test_months_to_payoff_interest(tmp_path):
 
     assert months_to_payoff(1000, 100, 0) == 10
     assert months_to_payoff(1000, 100, 20) > 10
+
+
+def test_set_account_with_apr_cli(tmp_path):
+    run_cli(tmp_path, "init")
+    run_cli(
+        tmp_path,
+        "set-account",
+        "Card",
+        "5000",
+        "--payment",
+        "50",
+        "--apr",
+        "10",
+    )
+    out = run_cli(tmp_path, "list-accounts").stdout
+    assert "Card" in out
+    months = None
+    for line in out.splitlines():
+        if "Card" in line:
+            months = int(line.split("months")[1].split(")")[0].strip())
+            break
+    assert months and months > 100


### PR DESCRIPTION
## Summary
- support APR and account details on CLI
- document new account options in README
- test account creation with APR via CLI

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454a5509748329ad13780b47550541