### PR TITLE
Add comma formatting for numbers

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from datetime import datetime
 import math
 
+
+def fmt(amount: float) -> str:
+    """Return a string with thousand separators and two decimals."""
+    return f"{amount:,.2f}"
+
 try:
     import auth
 except Exception:  # pragma: no cover - optional dependency
@@ -231,7 +236,7 @@ def set_account(
     )
     conn.commit()
     conn.close()
-    print(f"Account '{name}' set to {balance:.2f} with payment {payment:.2f}")
+    print(f"Account '{name}' set to {fmt(balance)} with payment {fmt(payment)}")
 
 
 def delete_account(name: str) -> None:
@@ -267,8 +272,8 @@ def list_accounts() -> None:
         )
         mtxt = f"{months}" if months is not None else "n/a"
         print(
-            f"- {row['name']} ({row['type']}): {row['balance']:.2f} "
-            f"(payment {row['monthly_payment']:.2f}, months {mtxt})"
+            f"- {row['name']} ({row['type']}): {fmt(row['balance'])} "
+            f"(payment {fmt(row['monthly_payment'])}, months {mtxt})"
         )
     if not rows:
         print("(none)")
@@ -348,7 +353,7 @@ def set_goal(category: str, amount: float, user: str = "default"):
             (cat_id, user_id, amount),
         )
         conn.commit()
-        print(f"Goal for {category} set to {amount:.2f} for {user}.")
+        print(f"Goal for {category} set to {fmt(amount)} for {user}.")
     except ValueError as e:
         print(e)
     finally:
@@ -429,7 +434,7 @@ def add_transaction(
         )
         conn.commit()
         print(
-            f"{trans_type.title()} of {amount:.2f} added to {name} for {user}."
+            f"{trans_type.title()} of {fmt(amount)} added to {name} for {user}."
         )
         if trans_type == "expense":
             cur = conn.execute(
@@ -451,7 +456,7 @@ def add_transaction(
                     print(
                         (
                             f"Warning: {user} exceeded goal for {name} ("
-                            f"{spent:.2f}/{goal_amount:.2f})"
+                            f"{fmt(spent)}/{fmt(goal_amount)})"
                         )
                     )
     except ValueError as e:
@@ -477,8 +482,8 @@ def category_balance(name: str, user: str = "default"):
         balance = income - expense
         print(
             (
-                f"Category: {name} ({user})\n  Income: {income:.2f}"
-                f"\n  Expense: {expense:.2f}\n  Balance: {balance:.2f}"
+                f"Category: {name} ({user})\n  Income: {fmt(income)}"
+                f"\n  Expense: {fmt(expense)}\n  Balance: {fmt(balance)}"
             )
         )
     except ValueError as e:
@@ -492,8 +497,8 @@ def show_totals(user: str = "default"):
     income, expense, net = calc_totals(user)
     print(
         (
-            f"Total Income: {income:.2f}\nTotal Expense: {expense:.2f}\n"
-            f"Net Balance: {net:.2f} ({user})"
+            f"Total Income: {fmt(income)}\nTotal Expense: {fmt(expense)}\n"
+            f"Net Balance: {fmt(net)} ({user})"
         )
     )
     warn = months_until_bank_negative(user)
@@ -549,7 +554,7 @@ def list_transactions(category: str | None, limit: int, user: str = "default"):
             desc = row[3] or ""
             item = row[4] or ""
             print(
-                f"{row[5]} | {row[0]} | {row[2]} | {row[1]:.2f} | {item} | {desc}"
+                f"{row[5]} | {row[0]} | {row[2]} | {fmt(row[1])} | {item} | {desc}"
             )
         if not rows:
             print("(no transactions)")
@@ -726,7 +731,7 @@ def main() -> None:
         init_db()
         bal = bank_balance_after_months(args.months)
         print(
-            f"Estimated bank balance after {args.months} months: {bal:.2f}"
+            f"Estimated bank balance after {args.months} months: {fmt(bal)}"
         )
     elif args.command == "delete-account":
         init_db()

--- a/templates/history.html
+++ b/templates/history.html
@@ -49,7 +49,7 @@
         <td>{{ row['created_at'] }}</td>
         <td>{{ row['name'] }}</td>
         <td>{{ row['type'] }}</td>
-        <td>{{ row['amount'] }}</td>
+        <td>{{ row['amount']|fmt }}</td>
         <td>{{ row['description'] or '' }}</td>
         <td>
           <form method="post" action="{{ url_for('delete_transaction', tid=row['id']) }}" style="display:inline">

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
       <tr>
         <td>{{ acc.type }}</td>
         <td>{{ acc.name }}</td>
-        <td>{{ acc.balance }}</td>
+        <td>{{ acc.balance|fmt }}</td>
       </tr>
     {% else %}
       <tr><td colspan="3">No accounts</td></tr>
@@ -53,9 +53,9 @@
   </table>
   <h2>Totals</h2>
   <ul>
-    <li>Income: {{ income|round(2) }}</li>
-    <li>Expense: {{ expense|round(2) }}</li>
-    <li>Net Balance: {{ net|round(2) }}</li>
+    <li>Income: {{ income|fmt }}</li>
+    <li>Expense: {{ expense|fmt }}</li>
+    <li>Net Balance: {{ net|fmt }}</li>
   </ul>
 
   <h2 class="d-flex align-items-center">Categories <button id="edit-cats" class="btn btn-sm btn-secondary ms-2">Edit</button></h2>

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -46,7 +46,7 @@ def test_income_expense_balance(tmp_path):
     run_cli(tmp_path, "add-income", "Salary", "1000")
     run_cli(tmp_path, "add-expense", "Salary", "200")
     bal = run_cli(tmp_path, "balance", "Salary").stdout
-    assert "Income: 1000.00" in bal
+    assert "Income: 1,000.00" in bal
     assert "Expense: 200.00" in bal
     assert "Balance: 800.00" in bal
 
@@ -58,9 +58,9 @@ def test_totals_output(tmp_path):
     run_cli(tmp_path, "add-income", "Job", "1500")
     run_cli(tmp_path, "add-expense", "Groceries", "500")
     totals = run_cli(tmp_path, "totals").stdout
-    assert "Total Income: 1500.00" in totals
+    assert "Total Income: 1,500.00" in totals
     assert "Total Expense: 500.00" in totals
-    assert "Net Balance: 1000.00" in totals
+    assert "Net Balance: 1,000.00" in totals
 
 
 def test_goal_warning(tmp_path):
@@ -123,7 +123,7 @@ def test_bank_balance_projection(tmp_path):
     budget_tool.DB_FILE = tmp_path / "budget.db"
     budget_tool.set_account("Bank", 1000, acct_type="Bank")
     out = run_cli(tmp_path, "bank-balance", "3").stdout
-    assert "1300.00" in out
+    assert "1,300.00" in out
 
 
 def test_totals_negative_warning(tmp_path):

--- a/webapp.py
+++ b/webapp.py
@@ -3,6 +3,12 @@ from flask import Flask, render_template, request, redirect, url_for
 
 app = Flask(__name__)
 
+
+@app.template_filter("fmt")
+def fmt_filter(value: float) -> str:
+    """Jinja filter to format numbers with commas and two decimals."""
+    return budget_tool.fmt(value)
+
 def setup_db() -> None:
     """Initialize the database tables if they do not exist."""
     budget_tool.init_db()


### PR DESCRIPTION
## Summary
- add `fmt` helper to format numeric values with thousand separators
- register Jinja `fmt` filter and use it in HTML templates
- apply the formatting in CLI outputs
- update tests for new output format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455808910c8329ae1997b108d17fbb