### PR TITLE
Add asset totals and account forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A simple command-line budgeting tool for tracking income and expenses. Data is s
 - Add income and expense entries associated with categories
 - View balances per category
 - View total income, total expenses and net balance
+- View available funds across bank, crypto and stock accounts
+- Forecast account balances for future months
 - Manage multiple users and set per-category spending goals
 - Export transactions to CSV
 - Login via Firebase ID token
@@ -24,7 +26,7 @@ python3 budget_tool.py add-expense <category> <amount> [--user NAME] [-d DESC]
 python3 budget_tool.py set-goal <category> <amount> [--user NAME]
 python3 budget_tool.py export-csv [--output FILE] [--user NAME]
 python3 budget_tool.py balance <category> [--user NAME]
-python3 budget_tool.py totals [--user NAME]            # show overall totals
+python3 budget_tool.py totals [--user NAME] [--months N] # show overall totals and forecast
 python3 budget_tool.py list                            # list all categories
 python3 budget_tool.py delete-category <name>          # remove a category
 python3 budget_tool.py set-account <name> <balance> [--payment AMT]

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -61,6 +61,7 @@ def test_totals_output(tmp_path):
     assert "Total Income: 1,500.00" in totals
     assert "Total Expense: 500.00" in totals
     assert "Net Balance: 1,000.00" in totals
+    assert "Total Assets: 0.00" in totals
 
 
 def test_goal_warning(tmp_path):
@@ -138,6 +139,7 @@ def test_totals_negative_warning(tmp_path):
     out = run_cli(tmp_path, "totals").stdout
     assert "Net Balance: -50.00" in out
     assert "negative in about 4 months" in out
+    assert "Total Assets: 200.00" in out
 
 
 def test_months_to_payoff_interest(tmp_path):
@@ -168,3 +170,16 @@ def test_set_account_with_apr_cli(tmp_path):
             months = int(line.split("months")[1].split(")")[0].strip())
             break
     assert months and months > 100
+
+
+def test_totals_forecast(tmp_path):
+    run_cli(tmp_path, "init")
+    run_cli(tmp_path, "add-category", "Job")
+    run_cli(tmp_path, "add-income", "Job", "1000")
+    import budget_tool
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    budget_tool.set_account("Card", 1000, payment=100, apr=12, acct_type="Credit Card")
+    out = run_cli(tmp_path, "totals", "--months", "1").stdout
+    assert "Account forecast after 1 month" in out
+    assert "Card" in out
+    assert "910.00" in out


### PR DESCRIPTION
## Summary
- show available funds and forecast in CLI totals
- support custom months forecast for totals command
- compute projected account balance via new helper
- expand README usage and feature docs
- test additional coverage for totals and forecast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e51729808329a1f118a52c0ee061