### PR TITLE
Expose goals and CSV export in web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ pip install -r requirements.txt
 python3 webapp.py
 ```
 
-This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances and add transactions using a basic Bootstrap UI.
+This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances, set spending goals, export transactions to CSV and add income or expenses using a basic Bootstrap UI.

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,7 @@
     <li>Expense: {{ expense|fmt }}</li>
     <li>Net Balance: {{ net|fmt }}</li>
   </ul>
+  <a class="btn btn-secondary mb-3" href="{{ url_for('export_csv_route') }}">Export CSV</a>
 
   <h2 class="d-flex align-items-center">Categories <button id="edit-cats" class="btn btn-sm btn-secondary ms-2">Edit</button></h2>
   <form method="post" action="{{ url_for('update_categories_route') }}" id="cats-form">
@@ -122,6 +123,45 @@
     </div>
     <div class="col-md-2">
       <button class="btn btn-success">Add</button>
+    </div>
+  </form>
+
+  <h3 class="mt-4">Budget Goals</h3>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Spent</th>
+        <th>Goal</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for g in goals %}
+      <tr>
+        <td>{{ g.category }}</td>
+        <td>{{ g.spent|fmt }}</td>
+        <td>{{ g.goal|fmt }}</td>
+      </tr>
+    {% else %}
+      <tr><td colspan="3">No goals</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <h4>Set Goal</h4>
+  <form method="post" action="{{ url_for('set_goal_route') }}" class="row g-2">
+    <div class="col-md-4">
+      <select name="category" class="form-select" required>
+        {% for cat in categories %}
+        <option value="{{ cat }}">{{ cat }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-3">
+      <input type="number" step="0.01" name="amount" class="form-control" placeholder="Amount" required>
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-secondary">Save</button>
     </div>
   </form>
 


### PR DESCRIPTION
## Summary
- add helper APIs to export CSV data and report goal status
- show goals and export button in the web UI
- add routes in the webapp for setting goals and exporting transactions
- document new web features in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e8df4968832988cc825020aa8aa7