### PR TITLE
Add account forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ python3 budget_tool.py set-account <name> <balance> [--payment AMT]
                              [--tax AMT]
 python3 budget_tool.py delete-account <name>           # remove an account
 python3 budget_tool.py list-accounts                   # show account balances
+python3 budget_tool.py forecast [--months N]           # forecast account balances
 python3 budget_tool.py bank-balance <months>           # forecast bank balance
 python3 budget_tool.py history [CATEGORY] [--user NAME] [--limit N]
 python3 budget_tool.py --db mydata.db totals          # use a custom database

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link id="theme-link" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/cyborg/bootstrap.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link id="font-link" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link id="custom-theme-link" rel="stylesheet" href="{{ url_for('static', filename='style-dark.css') }}">
+  <title>Account Forecast</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Budget Tool</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('history') }}">History</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="{{ url_for('forecast_route') }}">Forecast</a>
+        </li>
+        <li class="nav-item d-flex align-items-center ms-3">
+          <select id="theme-select" class="form-select form-select-sm">
+            <option value="cyborg">Cyborg</option>
+            <option value="darkly">Darkly</option>
+            <option value="flatly">Flatly</option>
+            <option value="litera">Litera</option>
+            <option value="solar">Solar</option>
+          </select>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+  <h1>Account Forecast</h1>
+  <form class="row gy-2 gx-3 mb-3">
+    <div class="col-auto">
+      <input type="number" class="form-control" name="months" value="{{ months }}" min="1">
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-secondary" type="submit">Update</button>
+    </div>
+  </form>
+  <h2>Accounts With Funds After {{ months }} {{ label }}</h2>
+  <table class="table table-bordered">
+    <thead><tr><th>Type</th><th>Name</th><th>Balance</th><th>Change</th></tr></thead>
+    <tbody>
+    {% for a in assets %}
+      <tr>
+        <td>{{ a.type }}</td><td>{{ a.name }}</td><td>{{ a.future|fmt }}</td>
+        <td>{{ a.change|fmt }}</td>
+      </tr>
+    {% else %}
+      <tr><td colspan="4">No accounts</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <h2>Accounts With Money Owed After {{ months }} {{ label }}</h2>
+  <table class="table table-bordered">
+    <thead><tr><th>Type</th><th>Name</th><th>Balance</th><th>Change</th></tr></thead>
+    <tbody>
+    {% for d in debts %}
+      <tr>
+        <td>{{ d.type }}</td><td>{{ d.name }}</td><td>{{ d.future|fmt }}</td>
+        <td>{{ d.change|fmt }}</td>
+      </tr>
+    {% else %}
+      <tr><td colspan="4">No accounts</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+<script>
+const themes = {
+  cyborg: {mode:'dark',font:"'Orbitron', sans-serif",url:'https://fonts.googleapis.com/css2?family=Orbitron&display=swap'},
+  darkly: {mode:'dark',font:"'Share Tech Mono', monospace",url:'https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap'},
+  flatly: {mode:'light',font:"'Open Sans', sans-serif",url:'https://fonts.googleapis.com/css2?family=Open+Sans&display=swap'},
+  litera: {mode:'light',font:"'Lora', serif",url:'https://fonts.googleapis.com/css2?family=Lora&display=swap'},
+  solar: {mode:'light',font:"'Inconsolata', monospace",url:'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap'}
+};
+const bootBase = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/';
+const staticBase = '{{ url_for("static", filename="") }}';
+const themeSelect = document.getElementById('theme-select');
+function applyTheme(name) {
+  if (!themes[name]) name = 'cyborg';
+  document.getElementById('theme-link').href = `${bootBase}${name}/bootstrap.min.css`;
+  const styleFile = themes[name].mode === 'dark' ? 'style-dark.css' : 'style-light.css';
+  document.getElementById('custom-theme-link').href = `${staticBase}${styleFile}`;
+  document.getElementById('font-link').href = themes[name].url;
+  document.documentElement.style.setProperty('--app-font', themes[name].font);
+  localStorage.setItem('theme', name);
+  themeSelect.value = name;
+}
+themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
+document.addEventListener('DOMContentLoaded', () => {
+  const saved = localStorage.getItem('theme') || 'cyborg';
+  applyTheme(saved);
+});
+</script>
+</body>
+</html>

--- a/templates/history.html
+++ b/templates/history.html
@@ -24,6 +24,9 @@
         <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="{{ url_for('history') }}">History</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
+        </li>
         <li class="nav-item d-flex align-items-center ms-3">
           <select id="theme-select" class="form-select form-select-sm">
             <option value="cyborg">Cyborg</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('history') }}">History</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
+        </li>
         <li class="nav-item d-flex align-items-center ms-3">
           <select id="theme-select" class="form-select form-select-sm">
             <option value="cyborg">Cyborg</option>

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -183,3 +183,16 @@ def test_totals_forecast(tmp_path):
     assert "Account forecast after 1 month" in out
     assert "Card" in out
     assert "910.00" in out
+
+
+def test_forecast_command(tmp_path):
+    run_cli(tmp_path, "init")
+    import budget_tool
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    budget_tool.set_account("Bank", 1000, acct_type="Bank")
+    budget_tool.set_account("Card", 500, payment=50, acct_type="Credit Card")
+    out = run_cli(tmp_path, "forecast", "--months", "2").stdout
+    assert "Accounts with funds after 2 months" in out
+    assert "Accounts with money owed after 2 months" in out
+    assert "Bank" in out
+    assert "Card" in out

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -71,3 +71,11 @@ def test_update_accounts_preserve_apr(tmp_path):
     months_no_interest = budget_tool.months_to_payoff(row["balance"], row["monthly_payment"], 0)
     assert months > months_no_interest
 
+
+def test_forecast_route(tmp_path):
+    client = setup_app(tmp_path)
+    budget_tool.set_account("Bank", 100, acct_type="Bank")
+    resp = client.get("/forecast")
+    assert resp.status_code == 200
+    assert b"Account Forecast" in resp.data
+


### PR DESCRIPTION
## Summary
- forecast future balances for assets and liabilities
- expose CLI command `forecast` for account forecasting
- add forecast page in the web app and link from navbars
- cover forecasting with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ed8add988329befe02dfcf92de5c