### PR TITLE
Add overview and manage pages

### DIFF
--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -12,14 +12,17 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">Budget Tool</a>
+    <a class="navbar-brand" href="{{ url_for('overview') }}">Budget Tool</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+          <a class="nav-link" href="{{ url_for('overview') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('manage') }}">Manage</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('history') }}">History</a>

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -12,14 +12,17 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
-    <a class="navbar-brand" href="{{ url_for('index') }}">Budget Tool</a>
+    <a class="navbar-brand" href="{{ url_for('overview') }}">Budget Tool</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+          <a class="nav-link" href="{{ url_for('overview') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="{{ url_for('manage') }}">Manage</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('history') }}">History</a>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link id="font-link" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   <link id="custom-theme-link" rel="stylesheet" href="{{ url_for('static', filename='style-dark.css') }}">
-  <title>Transaction History</title>
+  <title>Budget Overview</title>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -19,13 +19,13 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('overview') }}">Home</a>
+          <a class="nav-link active" aria-current="page" href="{{ url_for('overview') }}">Home</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('manage') }}">Manage</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="{{ url_for('history') }}">History</a>
+          <a class="nav-link" href="{{ url_for('history') }}">History</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
@@ -44,66 +44,67 @@
   </div>
 </nav>
 <div class="container mt-4">
-  <h1>Transaction History</h1>
-  <table class="table table-striped">
+  <h1>Overview</h1>
+  <h2>Accounts With Funds</h2>
+  <table class="table table-bordered">
     <thead>
       <tr>
-        <th>Item</th>
-        <th>Date</th>
-        <th>Category</th>
         <th>Type</th>
-        <th>Amount</th>
-        <th>Description</th>
-        <th></th>
+        <th>Name</th>
+        <th>Balance</th>
       </tr>
     </thead>
     <tbody>
-    {% for row in rows %}
+    {% for acc in assets %}
       <tr>
-        <td>{{ row['item_name'] or '' }}</td>
-        <td>{{ row['created_at'] }}</td>
-        <td>{{ row['name'] }}</td>
-        <td>{{ row['type'] }}</td>
-        <td>{{ row['amount']|fmt }}</td>
-        <td>{{ row['description'] or '' }}</td>
-        <td>
-          <form method="post" action="{{ url_for('delete_transaction', tid=row['id']) }}" style="display:inline">
-            <button class="btn btn-sm btn-danger">Delete</button>
-          </form>
-        </td>
+        <td>{{ acc.type }}</td>
+        <td>{{ acc.name }}</td>
+        <td>{{ acc.balance|fmt }}</td>
       </tr>
     {% else %}
-      <tr><td colspan="7">No transactions</td></tr>
+      <tr><td colspan="3">No accounts</td></tr>
     {% endfor %}
     </tbody>
   </table>
-  <script>
+  <h2>Totals</h2>
+  <ul>
+    <li>Total Income: {{ income|fmt }}</li>
+    <li>Total Expense: {{ expense|fmt }}</li>
+    <li>Net Balance: {{ net|fmt }}</li>
+  </ul>
+  <details class="mt-4">
+    <summary class="h4">Expenses</summary>
+    <table class="table table-striped mt-3">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Category</th>
+          <th>Amount</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for row in expenses %}
+        <tr>
+          <td>{{ row['created_at'] }}</td>
+          <td>{{ row['name'] }}</td>
+          <td>{{ row['amount']|fmt }}</td>
+          <td>{{ row['description'] or '' }}</td>
+        </tr>
+      {% else %}
+        <tr><td colspan="4">No expenses</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </details>
+</div>
+<script>
   const themes = {
-    cyborg: {
-      mode: 'dark',
-      font: "'Orbitron', sans-serif",
-      url: 'https://fonts.googleapis.com/css2?family=Orbitron&display=swap'
-    },
-    darkly: {
-      mode: 'dark',
-      font: "'Share Tech Mono', monospace",
-      url: 'https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap'
-    },
-    flatly: {
-      mode: 'light',
-      font: "'Open Sans', sans-serif",
-      url: 'https://fonts.googleapis.com/css2?family=Open+Sans&display=swap'
-    },
-    litera: {
-      mode: 'light',
-      font: "'Lora', serif",
-      url: 'https://fonts.googleapis.com/css2?family=Lora&display=swap'
-    },
-    solar: {
-      mode: 'light',
-      font: "'Inconsolata', monospace",
-      url: 'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap'
-    },
+    cyborg: { mode: 'dark', font: "'Orbitron', sans-serif", url: 'https://fonts.googleapis.com/css2?family=Orbitron&display=swap' },
+    darkly: { mode: 'dark', font: "'Share Tech Mono', monospace", url: 'https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap' },
+    flatly: { mode: 'light', font: "'Open Sans', sans-serif", url: 'https://fonts.googleapis.com/css2?family=Open+Sans&display=swap' },
+    litera: { mode: 'light', font: "'Lora', serif", url: 'https://fonts.googleapis.com/css2?family=Lora&display=swap' },
+    solar: { mode: 'light', font: "'Inconsolata', monospace", url: 'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap' }
   };
   const bootBase = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/';
   const staticBase = '{{ url_for("static", filename="") }}';
@@ -118,14 +119,12 @@
     localStorage.setItem('theme', name);
     themeSelect.value = name;
   }
-
   themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
   document.addEventListener('DOMContentLoaded', () => {
     const saved = localStorage.getItem('theme') || 'cyborg';
     applyTheme(saved);
   });
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
-</div>
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `overview` route and template with collapsible expenses
- move old index page to `manage` route
- update navigation links for new pages
- adjust redirects to go back to `/manage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f7fc33888329b0a6f4a78a68e1e7