### PR TITLE
Add auto-scan recurring expenses feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A simple command-line budgeting tool for tracking income and expenses. Data is s
 - Forecast account balances for future months
 - Manage multiple users and set per-category spending goals
 - Export transactions to CSV
+- Automatically detect recurring expenses from uploaded statements
 - Login via Firebase ID token
 
 ## Usage
@@ -64,3 +65,4 @@ python3 webapp.py
 ```
 
 This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances, set spending goals, export transactions to CSV and add income or expenses using a basic Bootstrap UI.
+The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses.

--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link id="theme-link" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/cyborg/bootstrap.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link id="font-link" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link id="custom-theme-link" rel="stylesheet" href="{{ url_for('static', filename='style-dark.css') }}">
+  <title>Auto Scan</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('overview') }}">Budget Tool</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('overview') }}">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('manage') }}">Manage</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">History</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+  <h1>Auto Scan</h1>
+  <form method="post" enctype="multipart/form-data" class="mb-4">
+    <input type="file" name="statement" multiple required>
+    <button class="btn btn-primary" type="submit">Scan</button>
+  </form>
+  {% if results %}
+  <h2>Recurring Expenses</h2>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th>Description</th><th>Amount</th></tr>
+    </thead>
+    <tbody>
+    {% for desc, amt in results %}
+      <tr><td>{{ desc }}</td><td>{{ amt|fmt }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <p>No recurring expenses found.</p>
+  {% endif %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import io
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -78,4 +79,19 @@ def test_forecast_route(tmp_path):
     resp = client.get("/forecast")
     assert resp.status_code == 200
     assert b"Account Forecast" in resp.data
+
+
+def test_auto_scan_route(tmp_path):
+    client = setup_app(tmp_path)
+    data1 = b"date,description,amount\n2023-01-01,Gym,10\n"
+    data2 = b"date,description,amount\n2023-02-01,Gym,10\n"
+    data = {
+        "statement": [
+            (io.BytesIO(data1), "jan.csv"),
+            (io.BytesIO(data2), "feb.csv"),
+        ]
+    }
+    resp = client.post("/auto-scan", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert b"Gym" in resp.data
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,3 +1,4 @@
+import io
 import budget_tool
 from flask import Flask, render_template, request, redirect, url_for, Response
 
@@ -201,6 +202,25 @@ def forecast_route():
         debts=debts,
         months=months,
         label=label,
+    )
+
+
+@app.route("/auto-scan", methods=["GET", "POST"])
+def auto_scan():
+    """Scan uploaded statements for recurring expenses."""
+    results = None
+    cats = get_categories()
+    if request.method == "POST" and request.files:
+        statements = []
+        files = request.files.getlist("statement")
+        for f in files:
+            if not f or not f.filename:
+                continue
+            data = io.StringIO(f.read().decode("utf-8"))
+            statements.append(budget_tool.parse_statement_csv(data))
+        results = budget_tool.find_recurring_expenses(statements)
+    return render_template(
+        "auto_scan.html", results=results or [], categories=cats
     )
 
 


### PR DESCRIPTION
## Summary
- add `TransactionRecord` dataclass and CSV parser
- implement recurring expense detection
- expose `/auto-scan` route in the Flask app
- create `auto_scan.html` template
- add unit tests for new utilities and route
- document auto scan usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fdbd8d2c83299367f19118933e5a