### PR TITLE
Add Auto Scan navigation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ python3 webapp.py
 
 This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances, set spending goals, export transactions to CSV and add income or expenses using a basic Bootstrap UI.
 The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses.
+Use the **Auto Scan** link in the navigation bar to access this page.

--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -21,6 +21,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('overview') }}">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('manage') }}">Manage</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">History</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="{{ url_for('auto_scan') }}">Auto Scan</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a></li>
       </ul>
     </div>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -28,6 +28,9 @@
           <a class="nav-link" href="{{ url_for('history') }}">History</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auto_scan') }}">Auto Scan</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link active" aria-current="page" href="{{ url_for('forecast_route') }}">Forecast</a>
         </li>
         <li class="nav-item d-flex align-items-center ms-3">

--- a/templates/history.html
+++ b/templates/history.html
@@ -28,6 +28,9 @@
           <a class="nav-link active" aria-current="page" href="{{ url_for('history') }}">History</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auto_scan') }}">Auto Scan</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
         </li>
         <li class="nav-item d-flex align-items-center ms-3">

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -28,6 +28,9 @@
           <a class="nav-link" href="{{ url_for('history') }}">History</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auto_scan') }}">Auto Scan</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
         </li>
         <li class="nav-item d-flex align-items-center ms-3">

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -28,6 +28,9 @@
           <a class="nav-link" href="{{ url_for('history') }}">History</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('auto_scan') }}">Auto Scan</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a>
         </li>
         <li class="nav-item d-flex align-items-center ms-3">

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -95,3 +95,10 @@ def test_auto_scan_route(tmp_path):
     assert resp.status_code == 200
     assert b"Gym" in resp.data
 
+
+def test_nav_contains_auto_scan(tmp_path):
+    client = setup_app(tmp_path)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"/auto-scan" in resp.data
+


### PR DESCRIPTION
## Summary
- add `Auto Scan` link across navigation bars so the page is accessible
- update README with instructions for using the Auto Scan page
- test that the main page contains a link to `/auto-scan`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ffa5cc648329b76fa871de21088f