### PR TITLE
Fix theme persistence on auto-scan page

### DIFF
--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -23,6 +23,15 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">History</a></li>
         <li class="nav-item"><a class="nav-link active" aria-current="page" href="{{ url_for('auto_scan') }}">Auto Scan</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a></li>
+        <li class="nav-item d-flex align-items-center ms-3">
+          <select id="theme-select" class="form-select form-select-sm">
+            <option value="cyborg">Cyborg</option>
+            <option value="darkly">Darkly</option>
+            <option value="flatly">Flatly</option>
+            <option value="litera">Litera</option>
+            <option value="solar">Solar</option>
+          </select>
+        </li>
       </ul>
     </div>
   </div>
@@ -49,6 +58,33 @@
     <p>No recurring expenses found.</p>
   {% endif %}
 </div>
+<script>
+  const themes = {
+    cyborg: { mode: 'dark', font: "'Orbitron', sans-serif", url: 'https://fonts.googleapis.com/css2?family=Orbitron&display=swap' },
+    darkly: { mode: 'dark', font: "'Share Tech Mono', monospace", url: 'https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap' },
+    flatly: { mode: 'light', font: "'Open Sans', sans-serif", url: 'https://fonts.googleapis.com/css2?family=Open+Sans&display=swap' },
+    litera: { mode: 'light', font: "'Lora', serif", url: 'https://fonts.googleapis.com/css2?family=Lora&display=swap' },
+    solar: { mode: 'light', font: "'Inconsolata', monospace", url: 'https://fonts.googleapis.com/css2?family=Inconsolata&display=swap' }
+  };
+  const bootBase = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/';
+  const staticBase = '{{ url_for("static", filename="") }}';
+  const themeSelect = document.getElementById('theme-select');
+  function applyTheme(name) {
+    if (!themes[name]) name = 'cyborg';
+    document.getElementById('theme-link').href = `${bootBase}${name}/bootstrap.min.css`;
+    const styleFile = themes[name].mode === 'dark' ? 'style-dark.css' : 'style-light.css';
+    document.getElementById('custom-theme-link').href = `${staticBase}${styleFile}`;
+    document.getElementById('font-link').href = themes[name].url;
+    document.documentElement.style.setProperty('--app-font', themes[name].font);
+    localStorage.setItem('theme', name);
+    themeSelect.value = name;
+  }
+  themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
+  document.addEventListener('DOMContentLoaded', () => {
+    const saved = localStorage.getItem('theme') || 'cyborg';
+    applyTheme(saved);
+  });
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep the selected theme on the Auto Scan page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846019027408329b5a7c25dae8be74c