### PR TITLE
Improve date header handling in CSV parser

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -65,7 +65,20 @@ def parse_statement_csv(path_or_file) -> list[TransactionRecord]:
             continue
         if has_header:
             mapping = {header[i]: row[i] for i in range(len(header))}
-            date_str = mapping.get("date", row[0])
+            date_key = None
+            for key in [
+                "date",
+                "posting date",
+                "effective date",
+                "transaction date",
+            ]:
+                if key in header:
+                    date_key = key
+                    break
+            if date_key:
+                date_str = mapping.get(date_key, row[0])
+            else:
+                date_str = row[0]
             desc = mapping.get("description", row[1])
             amt_str = mapping.get("amount", row[2])
         else:

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -211,6 +211,19 @@ def test_parse_statement_csv(tmp_path):
     assert records[0].amount == 10
 
 
+def test_parse_statement_csv_posting_date(tmp_path):
+    csv_text = "Posting Date,Description,Amount\n2023-01-01,Coffee,5"
+    f = tmp_path / "s2.csv"
+    f.write_text(csv_text)
+    from budget_tool import parse_statement_csv
+
+    records = parse_statement_csv(f)
+    assert len(records) == 1
+    assert records[0].description == "Coffee"
+    assert records[0].amount == 5
+    assert records[0].date == datetime(2023, 1, 1)
+
+
 def test_find_recurring_expenses():
     from budget_tool import TransactionRecord, find_recurring_expenses
     rec1 = [


### PR DESCRIPTION
## Summary
- add support for alternate date header names in CSV parser
- test parsing with "Posting Date" column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684605874b748329b1edf90205146d43