### PR TITLE
Support day window for recurring expenses

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -96,9 +96,22 @@ def parse_statement_csv(path_or_file) -> list[TransactionRecord]:
 
 
 def find_recurring_expenses(
-    statements: Sequence[Sequence[TransactionRecord]], tolerance: float = 0.1
+    statements: Sequence[Sequence[TransactionRecord]],
+    tolerance: float = 0.1,
+    day_window: int = 0,
 ) -> list[tuple[str, float]]:
-    """Return charges that repeat monthly with similar amount and day."""
+    """Return charges that repeat monthly with similar amount and day.
+
+    Parameters
+    ----------
+    statements : Sequence[Sequence[TransactionRecord]]
+        Lists of transactions grouped by month.
+    tolerance : float, optional
+        Allowed relative difference in amounts for a match.
+    day_window : int, optional
+        Accept matches that occur within this many days of the base day.
+        A value of ``0`` preserves the previous exact-day behaviour.
+    """
     if not statements:
         return []
 
@@ -118,7 +131,7 @@ def find_recurring_expenses(
             for r in other:
                 if (
                     r.description.lower() == base.description.lower()
-                    and r.date.day == base.date.day
+                    and abs(r.date.day - base.date.day) <= day_window
                     and abs(r.amount - base.amount)
                     <= abs(base.amount) * tolerance
                 ):

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -237,3 +237,14 @@ def test_find_recurring_expenses():
     res = find_recurring_expenses([rec1, rec2])
     names = [r[0] for r in res]
     assert "Gym" in names
+
+
+def test_find_recurring_expenses_day_window():
+    """Charges on adjacent days should match within the window."""
+    from budget_tool import TransactionRecord, find_recurring_expenses
+
+    jan = [TransactionRecord(datetime(2023, 1, 20), "Service", 30)]
+    feb = [TransactionRecord(datetime(2023, 2, 21), "Service", 29.9)]
+
+    res = find_recurring_expenses([jan, feb], day_window=1)
+    assert res and res[0][0] == "Service"

--- a/webapp.py
+++ b/webapp.py
@@ -218,7 +218,7 @@ def auto_scan():
                 continue
             data = io.StringIO(f.read().decode("utf-8"))
             statements.append(budget_tool.parse_statement_csv(data))
-        results = budget_tool.find_recurring_expenses(statements)
+        results = budget_tool.find_recurring_expenses(statements, day_window=1)
     return render_template(
         "auto_scan.html", results=results or [], categories=cats
     )


### PR DESCRIPTION
## Summary
- add `day_window` parameter to `find_recurring_expenses`
- use windowed comparison for recurring expenses
- scan statements with `day_window=1` in the webapp
- test recurring detection across adjacent days

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460a127cac832980a26a5ab2e36168