### PR TITLE
Enhance CSV parsing for auto scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ python3 webapp.py
 This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances, set spending goals, export transactions to CSV and add income or expenses using a basic Bootstrap UI.
 The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses.
 Use the **Auto Scan** link in the navigation bar to access this page.
+
+### Supported statement formats
+
+Uploaded CSV statements may be comma or tab delimited. The parser will automatically detect the delimiter. Dates may be in ISO format (`YYYY-MM-DD`), compact form (`YYYYMMDD`) or U.S. style (`MM/DD/YYYY`). The first row should include `Date`, `Description` and `Amount` columns.

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -224,6 +224,32 @@ def test_parse_statement_csv_posting_date(tmp_path):
     assert records[0].date == datetime(2023, 1, 1)
 
 
+def test_parse_statement_csv_tab_delimited(tmp_path):
+    csv_text = "date\tdescription\tamount\n2023-01-01\tGym\t10"
+    f = tmp_path / "tab.tsv"
+    f.write_text(csv_text)
+    from budget_tool import parse_statement_csv
+
+    records = parse_statement_csv(f)
+    assert len(records) == 1
+    assert records[0].description == "Gym"
+    assert records[0].amount == 10
+
+
+def test_parse_statement_csv_date_formats(tmp_path):
+    csv_text = (
+        "date,description,amount\n20230102,Gym,20\n01/03/2023,Store,5"
+    )
+    f = tmp_path / "dates.csv"
+    f.write_text(csv_text)
+    from budget_tool import parse_statement_csv
+
+    records = parse_statement_csv(f)
+    assert len(records) == 2
+    assert records[0].date == datetime(2023, 1, 2)
+    assert records[1].date == datetime(2023, 1, 3)
+
+
 def test_find_recurring_expenses():
     from budget_tool import TransactionRecord, find_recurring_expenses
     rec1 = [


### PR DESCRIPTION
## Summary
- auto-detect delimiters when parsing statement CSV files
- support multiple date formats in `parse_statement_csv`
- document supported statement formats in README
- test tab-delimited files and new date formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460bf414b48329a58946192107bfa7