### PR TITLE
Add selectable monthly expenses via Auto Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple command-line budgeting tool for tracking income and expenses. Data is s
 - Manage multiple users and set per-category spending goals
 - Export transactions to CSV
 - Automatically detect recurring expenses from uploaded statements
+- Store recurring charges as monthly expenses
 - Login via Firebase ID token
 
 ## Usage
@@ -65,7 +66,7 @@ python3 webapp.py
 ```
 
 This launches a local web server at `http://127.0.0.1:5000/` where you can view totals, manage categories, track account balances, set spending goals, export transactions to CSV and add income or expenses using a basic Bootstrap UI.
-The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses.
+The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses. After scanning, you can choose which charges to store as monthly expenses via check boxes before saving.
 Use the **Auto Scan** link in the navigation bar to access this page.
 
 ### Supported statement formats

--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -44,16 +44,27 @@
   </form>
   {% if results %}
   <h2>Recurring Expenses</h2>
+  <form method="post">
   <table class="table table-bordered">
     <thead>
-      <tr><th>Description</th><th>Amount</th></tr>
+      <tr><th></th><th>Description</th><th>Amount</th></tr>
     </thead>
     <tbody>
     {% for desc, amt in results %}
-      <tr><td>{{ desc }}</td><td>{{ amt|fmt }}</td></tr>
+      <tr>
+        <td class="text-center">
+          <input type="checkbox" name="add_{{ loop.index0 }}" class="form-check-input shadow-sm" checked>
+          <input type="hidden" name="desc_{{ loop.index0 }}" value="{{ desc }}">
+          <input type="hidden" name="amt_{{ loop.index0 }}" value="{{ amt }}">
+        </td>
+        <td>{{ desc }}</td>
+        <td>{{ amt|fmt }}</td>
+      </tr>
     {% endfor %}
     </tbody>
   </table>
+  <button class="btn btn-primary" type="submit">Save</button>
+  </form>
   {% else %}
     <p>No recurring expenses found.</p>
   {% endif %}

--- a/webapp.py
+++ b/webapp.py
@@ -218,7 +218,20 @@ def auto_scan():
                 continue
             data = io.StringIO(f.read().decode("utf-8"))
             statements.append(budget_tool.parse_statement_csv(data))
-        results = budget_tool.find_recurring_expenses(statements, day_window=1)
+        found = budget_tool.find_recurring_expenses(statements, day_window=1)
+        existing = {d for d, _ in budget_tool.get_monthly_expenses()}
+        results = [(d, a) for d, a in found if d not in existing]
+    elif request.method == "POST":
+        i = 0
+        while True:
+            desc = request.form.get(f"desc_{i}")
+            if desc is None:
+                break
+            amt = request.form.get(f"amt_{i}", type=float)
+            if request.form.get(f"add_{i}") == "on":
+                budget_tool.add_monthly_expense(desc, amt)
+            i += 1
+        results = []
     return render_template(
         "auto_scan.html", results=results or [], categories=cats
     )


### PR DESCRIPTION
## Summary
- track recurring charges in new `monthly_expenses` table
- allow Auto Scan results to be selected and saved
- skip already saved items on subsequent scans
- document monthly expenses and update Auto Scan instructions
- test saving monthly expenses via Auto Scan

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460e76bd34832994ee411fabd66f0d