### PR TITLE
Show saved monthly expenses on autoscan page

### DIFF
--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -68,6 +68,22 @@
   {% else %}
     <p>No recurring expenses found.</p>
   {% endif %}
+  <h2 class="mt-4">Saved Monthly Expenses</h2>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th>Description</th><th>Amount</th></tr>
+    </thead>
+    <tbody>
+    {% for desc, amt in monthly_expenses %}
+      <tr>
+        <td>{{ desc }}</td>
+        <td>{{ amt|fmt }}</td>
+      </tr>
+    {% else %}
+      <tr><td colspan="2">No monthly expenses saved.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
 </div>
 <script>
   const themes = {

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -102,7 +102,7 @@ def test_auto_scan_route(tmp_path):
     client.post("/auto-scan", data=save)
 
     resp2 = client.post("/auto-scan", data=build_data(), content_type="multipart/form-data")
-    assert b"Gym" not in resp2.data
+    assert b"name=\"add_0\"" not in resp2.data
 
 
 def test_nav_contains_auto_scan(tmp_path):

--- a/webapp.py
+++ b/webapp.py
@@ -232,8 +232,9 @@ def auto_scan():
                 budget_tool.add_monthly_expense(desc, amt)
             i += 1
         results = []
+    expenses = budget_tool.get_monthly_expenses()
     return render_template(
-        "auto_scan.html", results=results or [], categories=cats
+        "auto_scan.html", results=results or [], categories=cats, monthly_expenses=expenses
     )
 
 


### PR DESCRIPTION
## Summary
- display saved monthly expenses on the Auto Scan page
- fetch monthly expenses in the `/auto-scan` route
- adjust Auto Scan route test for new table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846112d38ac83299fe29053dd63fe17