### PR TITLE
Fix negative autoscan amounts

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -157,7 +157,7 @@ def find_recurring_expenses(
             amounts.append(match_amt)
         else:  # only executed if no break occurred -> found in all months
             avg = sum(amounts) / len(amounts)
-            recurring.append((base.description, avg))
+            recurring.append((base.description, abs(avg)))
 
     return recurring
 
@@ -480,6 +480,7 @@ def add_monthly_expense(
     desc: str, amount: float, category: str = "Misc", user: str = "default"
 ) -> None:
     """Insert or replace a monthly expense and create a transaction if needed."""
+    amount = abs(amount)
     conn = get_connection()
     conn.execute(
         "INSERT OR REPLACE INTO monthly_expenses(description, amount) VALUES(?,?)",

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -274,3 +274,32 @@ def test_find_recurring_expenses_day_window():
 
     res = find_recurring_expenses([jan, feb], day_window=1)
     assert res and res[0][0] == "Service"
+
+
+def test_find_recurring_expenses_positive_amount():
+    """Negative amounts should be returned as positive values."""
+    from budget_tool import TransactionRecord, find_recurring_expenses
+
+    jan = [TransactionRecord(datetime(2023, 1, 1), "Gym", -10)]
+    feb = [TransactionRecord(datetime(2023, 2, 1), "Gym", -10)]
+
+    res = find_recurring_expenses([jan, feb])
+    assert res and res[0][1] == 10
+
+
+def test_add_monthly_expense_abs(tmp_path):
+    import budget_tool
+
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    budget_tool.init_db()
+    budget_tool.add_category("Misc")
+    budget_tool.add_monthly_expense("Gym", -20)
+
+    conn = budget_tool.get_connection()
+    amt = conn.execute(
+        "SELECT amount FROM monthly_expenses WHERE description=?",
+        ("Gym",),
+    ).fetchone()[0]
+    conn.close()
+    assert amt == 20
+


### PR DESCRIPTION
## Summary
- ensure recurring expense averages are returned as positive values
- store monthly expenses as positive numbers
- test that monthly expenses are positive
- test positive amounts from autoscan

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461d959e6c8329b213d1d6f1b47258