### PR TITLE
Fix SQL comment inside get_goal_status

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -675,10 +675,9 @@ def get_goal_status(user: str = "default") -> list[tuple[str, float, float]]:
     cur = conn.execute(
         """
         SELECT c.name, g.amount,
-            (SELECT SUM(t.amount) FROM transactions t
-             WHERE t.category_id = c.id AND t.user_id=? AND t.type='expense') as spent  # noqa: E501
+               (SELECT SUM(t.amount) FROM transactions t
+                WHERE t.category_id = c.id AND t.user_id=? AND t.type='expense') AS spent
         FROM goals g
-        FROM transactions t
         JOIN categories c ON g.category_id = c.id
         WHERE g.user_id=?
         ORDER BY c.name


### PR DESCRIPTION
## Summary
- fix SQL query in `get_goal_status` that accidentally included a Python comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463722d95c8329af18c7f69bc80073