### PR TITLE
Add authentication and recurring income

### DIFF
--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -32,6 +32,13 @@
             <option value="solar">Solar</option>
           </select>
         </li>
+        <li class="nav-item">
+          {% if session.get('user') %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          {% else %}
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          {% endif %}
+        </li>
       </ul>
     </div>
   </div>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -42,6 +42,13 @@
             <option value="solar">Solar</option>
           </select>
         </li>
+        <li class="nav-item">
+          {% if session.get('user') %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          {% else %}
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          {% endif %}
+        </li>
       </ul>
     </div>
   </div>

--- a/templates/history.html
+++ b/templates/history.html
@@ -42,12 +42,30 @@
             <option value="solar">Solar</option>
           </select>
         </li>
+        <li class="nav-item">
+          {% if session.get('user') %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          {% else %}
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          {% endif %}
+        </li>
       </ul>
     </div>
   </div>
 </nav>
 <div class="container mt-4">
   <h1>Transaction History</h1>
+  <form class="row g-2 mb-3" method="get">
+    <div class="col-auto">
+      <input type="date" name="start" class="form-control" value="{{ request.args.get('start', '') }}">
+    </div>
+    <div class="col-auto">
+      <input type="date" name="end" class="form-control" value="{{ request.args.get('end', '') }}">
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-secondary">Filter</button>
+    </div>
+  </form>
   <table class="table table-striped">
     <thead>
       <tr>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link id="theme-link" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/cyborg/bootstrap.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link id="font-link" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link id="custom-theme-link" rel="stylesheet" href="{{ url_for('static', filename='style-dark.css') }}">
+  <title>Login</title>
+</head>
+<body>
+<div class="container mt-4">
+  <h1>Login</h1>
+  <form method="post">
+    <div class="mb-3">
+      <input name="token" class="form-control" placeholder="ID Token" required>
+    </div>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <button class="btn btn-primary">Login</button>
+  </form>
+</div>
+<script src="{{ url_for('static', filename='theme.js') }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -42,6 +42,13 @@
             <option value="solar">Solar</option>
           </select>
         </li>
+        <li class="nav-item">
+          {% if session.get('user') %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          {% else %}
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          {% endif %}
+        </li>
       </ul>
     </div>
   </div>
@@ -273,6 +280,48 @@
     </div>
     <div class="col-md-2 d-none" id="tax-field">
       <input type="number" step="0.01" name="tax" class="form-control" placeholder="Property Tax">
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-secondary">Save</button>
+    </div>
+  </form>
+
+  <h4 class="mt-4">Monthly Income</h4>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th>Description</th><th>Amount</th><th></th></tr>
+    </thead>
+    <tbody>
+    {% for desc, amt in monthly_incomes %}
+      <tr>
+        <td>{{ desc }}</td>
+        <td>{{ amt|fmt }}</td>
+        <td>
+          <form method="post" action="{{ url_for('delete_monthly_income_route', desc=desc) }}">
+            <button class="btn btn-sm btn-danger">Delete</button>
+          </form>
+        </td>
+      </tr>
+    {% else %}
+      <tr><td colspan="3">No monthly income</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+
+  <h5>Add Monthly Income</h5>
+  <form method="post" action="{{ url_for('add_monthly_income_route') }}" class="row g-2">
+    <div class="col-md-4">
+      <input name="desc" class="form-control" placeholder="Description" required>
+    </div>
+    <div class="col-md-3">
+      <input type="number" step="0.01" name="amount" class="form-control" placeholder="Amount" required>
+    </div>
+    <div class="col-md-3">
+      <select name="category" class="form-select">
+        {% for cat in categories %}
+        <option value="{{ cat }}">{{ cat }}</option>
+        {% endfor %}
+      </select>
     </div>
     <div class="col-md-2">
       <button class="btn btn-secondary">Save</button>

--- a/templates/overview.html
+++ b/templates/overview.html
@@ -42,6 +42,13 @@
             <option value="solar">Solar</option>
           </select>
         </li>
+        <li class="nav-item">
+          {% if session.get('user') %}
+          <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          {% else %}
+          <a class="nav-link" href="{{ url_for('login') }}">Login</a>
+          {% endif %}
+        </li>
       </ul>
     </div>
   </div>

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -303,3 +303,25 @@ def test_add_monthly_expense_abs(tmp_path):
     conn.close()
     assert amt == 20
 
+
+def test_monthly_income_functions(tmp_path):
+    import budget_tool
+
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    budget_tool.init_db()
+    budget_tool.add_category("Job")
+    budget_tool.add_monthly_income("Salary", 100, "Job")
+
+    conn = budget_tool.get_connection()
+    cur = conn.execute(
+        "SELECT count(*) FROM monthly_incomes WHERE description=?",
+        ("Salary",),
+    )
+    assert cur.fetchone()[0] == 1
+    cur = conn.execute(
+        "SELECT count(*) FROM transactions WHERE description=?",
+        ("Salary",),
+    )
+    assert cur.fetchone()[0] == 1
+    conn.close()
+


### PR DESCRIPTION
## Summary
- secure key-based auth in Flask webapp
- support recurring monthly income
- require login on more routes
- allow filtering history by date range
- list monthly income on manage page
- add login nav links
- fix and extend unit tests

## Testing
- `pip install -q -r requirements.txt`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463854a5e08329b1b8fdc3ecf26bb4