### PR TITLE
Disable auth by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ A simple command-line budgeting tool for tracking income and expenses. Data is s
 - Automatically detect recurring expenses from uploaded statements
 - Store recurring charges as monthly expenses
 - Login via Firebase ID token
+  - Authentication is disabled by default; set `AUTH_ENABLED=1` to enable
 
 ## Usage
 Run the CLI with Python 3:
 
 ```bash
 python3 budget_tool.py init                            # initialize the database
-python3 budget_tool.py login <id_token>               # verify Firebase token
+AUTH_ENABLED=1 python3 budget_tool.py login <id_token> # verify Firebase token
 python3 budget_tool.py add-user <name>                 # add a user
 python3 budget_tool.py add-category <name>             # add a category
 python3 budget_tool.py add-income <category> <amount> [--user NAME] [-d DESC]

--- a/budget_tool.py
+++ b/budget_tool.py
@@ -22,6 +22,7 @@ try:
     import auth
 except Exception:  # pragma: no cover - optional dependency
     auth = None
+AUTH_ENABLED = os.environ.get("AUTH_ENABLED", "0") == "1"
 
 DEFAULT_DB = Path(__file__).with_name("budget.db")
 DB_FILE = Path(os.environ.get("BUDGET_DB", DEFAULT_DB))
@@ -621,6 +622,9 @@ def months_to_payoff(
 
 def login_user(id_token: str) -> str | None:
     """Verify a Firebase ID token and record the user in the database."""
+    if not AUTH_ENABLED:
+        print("Authentication disabled; using default user")
+        return "default"
     if auth is None:
         print("Login failed: firebase_admin not available")
         return None

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -122,8 +122,7 @@ def test_nav_contains_auto_scan(tmp_path):
 def test_protected_requires_login(tmp_path):
     client = setup_app(tmp_path)
     resp = client.get("/manage")
-    assert resp.status_code == 302
-    assert resp.headers["Location"].endswith("/login")
+    assert resp.status_code == 200
 
 
 def test_delete_monthly_expense(tmp_path):

--- a/webapp.py
+++ b/webapp.py
@@ -14,6 +14,7 @@ from flask import (
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "devkey")
+AUTH_ENABLED = os.environ.get("AUTH_ENABLED", "0") == "1"
 
 
 @app.template_filter("fmt")
@@ -26,7 +27,7 @@ def require_login(func):
     """Decorator to ensure a user is logged in."""
     @wraps(func)
     def wrapper(*args, **kwargs):
-        if not session.get("user"):
+        if AUTH_ENABLED and not session.get("user"):
             return redirect(url_for("login"))
         return func(*args, **kwargs)
 
@@ -188,6 +189,9 @@ def get_account_forecast(months: int = 1):
 @app.route("/login", methods=["GET", "POST"])
 def login():
     error = None
+    if not AUTH_ENABLED:
+        session["user"] = "default"
+        return redirect(url_for("overview"))
     if request.method == "POST":
         token = request.form.get("token", "")
         username = budget_tool.login_user(token)


### PR DESCRIPTION
## Summary
- make authentication optional using an `AUTH_ENABLED` flag
- bypass login requirements in the web app when auth is disabled
- adjust README instructions for enabling auth
- update test expectations when auth is turned off

## Testing
- `pip install -q Flask pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684647551c8c83299eae4de463df823d