### PR TITLE
Cleanup imports and docs, add CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+*.db
+.env
+.mypy_cache/
+*.sqlite3
+
+# VSCode
+.vscode/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ This launches a local web server at `http://127.0.0.1:5000/` where you can view 
 The interface also provides an **Auto Scan** page for uploading CSV statements and identifying recurring expenses. After scanning, you can choose which charges to store as monthly expenses via check boxes before saving.
 Use the **Auto Scan** link in the navigation bar to access this page.
 
+### Environment Variables
+
+The web server reads `FLASK_SECRET_KEY` to sign session cookies. Set this to a
+secure random value when deploying. Firebase authentication also requires the
+`FIREBASE_CREDENTIALS` variable pointing to your service account JSON file and
+`AUTH_ENABLED=1` to enable login.
+
 ### Supported statement formats
 
 Uploaded CSV statements may be comma or tab delimited. The parser will automatically detect the delimiter. Dates may be in ISO format (`YYYY-MM-DD`), compact form (`YYYYMMDD`) or U.S. style (`MM/DD/YYYY`). The first row should include `Date`, `Description` and `Amount` columns.

--- a/budget_tool.py
+++ b/budget_tool.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import math
 import io
 from dataclasses import dataclass
-from typing import Iterable, Sequence
+from typing import Sequence
 
 
 def fmt(amount: float) -> str:

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -324,4 +324,3 @@ def test_monthly_income_functions(tmp_path):
     )
     assert cur.fetchone()[0] == 1
     conn.close()
-

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -147,7 +147,7 @@ def test_delete_monthly_expense(tmp_path):
 
 
 def test_monthly_expense_creates_transaction(tmp_path):
-    client = setup_app(tmp_path)
+    _ = setup_app(tmp_path)
     budget_tool.add_category("Misc")
     budget_tool.add_monthly_expense("Gym", 10)
 

--- a/webapp.py
+++ b/webapp.py
@@ -1,6 +1,7 @@
 import io
 import budget_tool
 import os
+from typing import Any
 from functools import wraps
 from flask import (
     Flask,
@@ -114,7 +115,7 @@ def get_history(
         "t.item_name, t.created_at FROM transactions t "
         "JOIN categories c ON t.category_id = c.id WHERE t.user_id = ?"
     )
-    params = [user_id]
+    params: list[Any] = [user_id]
     if start:
         query += " AND t.created_at >= ?"
         params.append(start)


### PR DESCRIPTION
## Summary
- remove unused Iterable import
- fix param typing in `get_history`
- remove unused variable in test
- trim trailing newline
- add `.gitignore`
- document env vars for auth
- add basic GitHub Actions workflow

## Testing
- `mypy --ignore-missing-imports --follow-imports=skip webapp.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846732632a08329813064b7c57d4165