### PR TITLE
Add fade-out transition between pages

### DIFF
--- a/static/style-dark.css
+++ b/static/style-dark.css
@@ -72,3 +72,12 @@ a, a:hover {
 .card:hover {
     transform: translateY(-4px);
 }
+
+body.fade-out {
+    animation: fade-out 0.5s ease-out forwards;
+}
+
+@keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}

--- a/static/style-light.css
+++ b/static/style-light.css
@@ -72,3 +72,12 @@ a, a:hover {
 .card:hover {
     transform: translateY(-4px);
 }
+
+body.fade-out {
+    animation: fade-out 0.5s ease-out forwards;
+}
+
+@keyframes fade-out {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}

--- a/static/theme.js
+++ b/static/theme.js
@@ -26,4 +26,19 @@ document.addEventListener('DOMContentLoaded', () => {
     saved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'cyborg' : 'flatly';
   }
   applyTheme(saved);
+
+  document.addEventListener('click', (e) => {
+    const link = e.target.closest('a');
+    if (!link) return;
+    const href = link.getAttribute('href');
+    if (!href || href.startsWith('#') || link.getAttribute('target') === '_blank' || link.getAttribute('data-bs-toggle')) {
+      return;
+    }
+    if (link.hostname !== window.location.hostname) return;
+    e.preventDefault();
+    document.body.classList.add('fade-out');
+    setTimeout(() => {
+      window.location.href = href;
+    }, 500);
+  });
 });


### PR DESCRIPTION
## Summary
- add fade-out animation styles for dark and light themes
- intercept anchor clicks in `theme.js` to animate page exit before navigation

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684697aba4d88329895fabd0676dec65