### PR TITLE
Add one-time expense deletion option

### DIFF
--- a/budget_tool.py
+++ b/budget_tool.py
@@ -638,6 +638,19 @@ def one_time_total() -> float:
     return total
 
 
+def delete_one_time_expenses(ids: Sequence[int]) -> None:
+    """Delete one time expenses by ID."""
+    if not ids:
+        return
+    conn = get_connection()
+    placeholders = ",".join("?" for _ in ids)
+    conn.execute(
+        f"DELETE FROM one_time_expenses WHERE id IN ({placeholders})", tuple(ids)
+    )
+    conn.commit()
+    conn.close()
+
+
 def convert_one_time_to_monthly(oid: int) -> None:
     """Convert a one time expense to a recurring monthly expense."""
     conn = get_connection()

--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -56,18 +56,27 @@
     </tbody>
   </table>
 
-  <h2 class="mt-4">One Time Expenses (Total {{ one_time_total|fmt }})</h2>
-  <table class="table table-bordered">
+  <h2 class="mt-4">
+    One Time Expenses (Total {{ one_time_total|fmt }})
+    <button id="edit-one-time" class="btn btn-sm btn-secondary ms-2">Edit</button>
+  </h2>
+  <form method="post" action="{{ url_for('delete_one_time_route') }}" id="one-time-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  </form>
+  <table class="table table-bordered" id="one-time-table">
     <thead>
-      <tr><th>Description</th><th>Amount</th><th>Date</th><th></th></tr>
+      <tr><th class="edit-col d-none"></th><th>Description</th><th>Amount</th><th>Date</th><th class="edit-col d-none"></th></tr>
     </thead>
     <tbody>
     {% for e in one_time_expenses %}
       <tr>
+        <td class="edit-col d-none text-center">
+          <input type="checkbox" form="one-time-form" name="delete" value="{{ e[0] }}" class="form-check-input">
+        </td>
         <td>{{ e[1] }}</td>
         <td>{{ e[2]|fmt }}</td>
         <td>{{ e[3][:10] }}</td>
-        <td>
+        <td class="edit-col d-none">
           <form method="post" action="{{ url_for('convert_one_time_expense', oid=e[0]) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button class="btn btn-sm btn-primary">Make Monthly</button>
@@ -75,9 +84,17 @@
         </td>
       </tr>
     {% else %}
-      <tr><td colspan="4">No one time expenses</td></tr>
+      <tr><td colspan="5">No one time expenses</td></tr>
     {% endfor %}
     </tbody>
   </table>
+  <div class="text-end edit-col d-none mb-3">
+    <button class="btn btn-danger" form="one-time-form">Delete</button>
+  </div>
+  <script>
+  document.getElementById('edit-one-time').addEventListener('click', () => {
+    document.querySelectorAll('.edit-col').forEach(el => el.classList.toggle('d-none'));
+  });
+  </script>
 </div>
 {% endblock %}

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -162,6 +162,18 @@ def test_auto_scan_one_time(tmp_path, monkeypatch):
     assert budget_tool.monthly_expense_exists("Coffee")
 
 
+def test_delete_one_time(tmp_path, monkeypatch):
+    client = setup_app(tmp_path)
+    login(client, monkeypatch)
+    from datetime import datetime
+    budget_tool.add_one_time_expense("Temp", 5, datetime(2023, 1, 1))
+    oid = budget_tool.get_one_time_expenses()[0][0]
+    token = get_csrf(client, "/auto-scan")
+    resp = client.post("/delete-one-time", data={"delete": str(oid), "csrf_token": token})
+    assert resp.status_code == 302
+    assert budget_tool.get_one_time_expenses() == []
+
+
 def test_nav_contains_auto_scan(tmp_path):
     client = setup_app(tmp_path)
     resp = client.get("/")

--- a/webapp.py
+++ b/webapp.py
@@ -365,6 +365,14 @@ def convert_one_time_expense(oid: int):
     return redirect(url_for("auto_scan"))
 
 
+@app.route("/delete-one-time", methods=["POST"])
+def delete_one_time_route():
+    """Delete selected one time expenses."""
+    ids = [int(i) for i in request.form.getlist("delete")]
+    budget_tool.delete_one_time_expenses(ids)
+    return redirect(url_for("auto_scan"))
+
+
 @app.route("/add-monthly-income", methods=["POST"])
 @require_login
 def add_monthly_income_route():


### PR DESCRIPTION
## Summary
- allow deleting one-time expenses
- show edit mode for one-time expenses with checkboxes, delete and make monthly buttons
- add server route and backend function for deletion
- test deleting one-time expenses

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a66d80248329bb39467237236198