### PR TITLE
Improve auto-scan management UI

### DIFF
--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -33,28 +33,35 @@
   {% else %}
     <p>No recurring expenses found.</p>
   {% endif %}
-  <h2 class="mt-4">Saved Monthly Expenses</h2>
-  <table class="table table-bordered">
+  <h2 class="mt-4">
+    Saved Monthly Expenses
+    <button id="edit-monthly" class="btn btn-sm btn-secondary ms-2">Edit</button>
+  </h2>
+  <form method="post" action="{{ url_for('delete_monthly_multiple') }}" id="monthly-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  </form>
+  <table class="table table-bordered" id="monthly-table">
     <thead>
-      <tr><th>Description</th><th>Amount</th><th></th></tr>
+      <tr><th class="m-edit-col d-none"></th><th>Description</th><th>Amount</th><th class="m-edit-col d-none"></th></tr>
     </thead>
     <tbody>
     {% for desc, amt in monthly_expenses %}
       <tr>
+        <td class="m-edit-col d-none text-center">
+          <input type="checkbox" form="monthly-form" name="delete" value="{{ desc }}" class="form-check-input">
+        </td>
         <td>{{ desc }}</td>
         <td>{{ amt|fmt }}</td>
-        <td>
-          <form method="post" action="{{ url_for('delete_monthly_expense_route', desc=desc) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-sm btn-danger">Delete</button>
-          </form>
-        </td>
+        <td class="m-edit-col d-none"></td>
       </tr>
     {% else %}
-      <tr><td colspan="3">No monthly expenses saved.</td></tr>
+      <tr><td colspan="4">No monthly expenses saved.</td></tr>
     {% endfor %}
     </tbody>
   </table>
+  <div class="text-end m-edit-col d-none mb-3">
+    <button class="btn btn-danger" form="monthly-form">Delete</button>
+  </div>
 
   <h2 class="mt-4">
     One Time Expenses (Total {{ one_time_total|fmt }})
@@ -63,38 +70,75 @@
   <form method="post" action="{{ url_for('delete_one_time_route') }}" id="one-time-form">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   </form>
-  <table class="table table-bordered" id="one-time-table">
-    <thead>
-      <tr><th class="edit-col d-none"></th><th>Description</th><th>Amount</th><th>Date</th><th class="edit-col d-none"></th></tr>
-    </thead>
-    <tbody>
-    {% for e in one_time_expenses %}
-      <tr>
-        <td class="edit-col d-none text-center">
-          <input type="checkbox" form="one-time-form" name="delete" value="{{ e[0] }}" class="form-check-input">
-        </td>
-        <td>{{ e[1] }}</td>
-        <td>{{ e[2]|fmt }}</td>
-        <td>{{ e[3][:10] }}</td>
-        <td class="edit-col d-none">
-          <form method="post" action="{{ url_for('convert_one_time_expense', oid=e[0]) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-sm btn-primary">Make Monthly</button>
-          </form>
-        </td>
-      </tr>
-    {% else %}
-      <tr><td colspan="5">No one time expenses</td></tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  <div class="accordion" id="oneTimeAccordion">
+  {% for month in one_time_expenses %}
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="heading{{ loop.index }}">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ loop.index }}" aria-expanded="false" aria-controls="collapse{{ loop.index }}">
+          {{ month.label }} ({{ month.total|fmt }})
+        </button>
+      </h2>
+      <div id="collapse{{ loop.index }}" class="accordion-collapse collapse" aria-labelledby="heading{{ loop.index }}" data-bs-parent="#oneTimeAccordion">
+        <div class="accordion-body p-0">
+          <table class="table mb-0">
+            <thead>
+              <tr><th class="edit-col d-none"></th><th>Description</th><th>Amount</th><th>Date</th><th class="edit-col d-none"></th></tr>
+            </thead>
+            <tbody>
+            {% for e in month["items"] %}
+              <tr>
+                <td class="edit-col d-none text-center">
+                  <input type="checkbox" form="one-time-form" name="delete" value="{{ e[0] }}" class="form-check-input">
+                </td>
+                <td>{{ e[1] }}</td>
+                <td>{{ e[2]|fmt }}</td>
+                <td>{{ e[3][:10] }}</td>
+                <td class="edit-col d-none">
+                  <form method="post" action="{{ url_for('convert_one_time_expense', oid=e[0]) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button class="btn btn-sm btn-primary">Make Monthly</button>
+                  </form>
+                </td>
+              </tr>
+            {% else %}
+              <tr><td colspan="5">No one time expenses</td></tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  {% else %}
+    <p>No one time expenses</p>
+  {% endfor %}
+  </div>
   <div class="text-end edit-col d-none mb-3">
     <button class="btn btn-danger" form="one-time-form">Delete</button>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
   document.getElementById('edit-one-time').addEventListener('click', () => {
     document.querySelectorAll('.edit-col').forEach(el => el.classList.toggle('d-none'));
   });
+  document.getElementById('edit-monthly').addEventListener('click', () => {
+    document.querySelectorAll('.m-edit-col').forEach(el => el.classList.toggle('d-none'));
+  });
+
+  const chartData = {{ one_time_chart|tojson }};
+  if (chartData.length) {
+    const ctx = document.createElement('canvas');
+    ctx.id = 'oneTimeChart';
+    ctx.height = 200;
+    document.getElementById('oneTimeAccordion').before(ctx);
+    new Chart(ctx.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: chartData.map(r => r[0]),
+        datasets: [{label: 'Spent', data: chartData.map(r => r[1]), backgroundColor: '#0d6efd'}]
+      },
+      options: {plugins:{legend:{display:false}}}
+    });
+  }
   </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add duplicate check when storing one-time expenses
- group one-time expenses by month with bar chart visualization
- allow bulk deletion of monthly expenses
- provide edit mode for saved monthly expenses
- test new monthly delete and duplicate logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846a918a6b88329a026618c748581af