### PR TITLE
Use CSV categories when saving monthly expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ secure random value when deploying. Firebase authentication also requires the
 
 ### Supported statement formats
 
-Uploaded CSV statements may be comma or tab delimited. The parser will automatically detect the delimiter. Dates may be in ISO format (`YYYY-MM-DD`), compact form (`YYYYMMDD`) or U.S. style (`MM/DD/YYYY`). The first row should include `Date`, `Description` and `Amount` columns.
+Uploaded CSV statements may be comma or tab delimited. The parser will automatically detect the delimiter. Dates may be in ISO format (`YYYY-MM-DD`), compact form (`YYYYMMDD`) or U.S. style (`MM/DD/YYYY`). The first row should include `Date`, `Description` and `Amount` columns. If a column containing the word `Category` (e.g. `Transaction Category`) is present it will be used to assign categories when saving monthly expenses.

--- a/templates/auto_scan.html
+++ b/templates/auto_scan.html
@@ -12,18 +12,20 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <table class="table table-bordered">
     <thead>
-      <tr><th></th><th>Description</th><th>Amount</th></tr>
+      <tr><th></th><th>Description</th><th>Amount</th><th>Category</th></tr>
     </thead>
     <tbody>
-    {% for desc, amt in results %}
+    {% for desc, amt, cat in results %}
       <tr>
         <td class="text-center">
           <input type="checkbox" name="add_{{ loop.index0 }}" class="form-check-input shadow-sm" checked>
           <input type="hidden" name="desc_{{ loop.index0 }}" value="{{ desc }}">
           <input type="hidden" name="amt_{{ loop.index0 }}" value="{{ amt }}">
+          <input type="hidden" name="cat_{{ loop.index0 }}" value="{{ cat }}">
         </td>
         <td>{{ desc }}</td>
         <td>{{ amt|fmt }}</td>
+        <td>{{ cat or 'Misc' }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/tests/test_budget_tool.py
+++ b/tests/test_budget_tool.py
@@ -209,10 +209,12 @@ def test_parse_statement_csv(tmp_path):
     assert len(records) == 2
     assert records[0].description == "Gym"
     assert records[0].amount == 10
+    assert records[0].category is None
 
 
 def test_parse_statement_csv_posting_date(tmp_path):
-    csv_text = "Posting Date,Description,Amount\n2023-01-01,Coffee,5"
+    csv_text = "Posting Date,Description,Amount,Transaction Category\n" \
+        "2023-01-01,Coffee,5,Drinks"
     f = tmp_path / "s2.csv"
     f.write_text(csv_text)
     from budget_tool import parse_statement_csv
@@ -222,6 +224,7 @@ def test_parse_statement_csv_posting_date(tmp_path):
     assert records[0].description == "Coffee"
     assert records[0].amount == 5
     assert records[0].date == datetime(2023, 1, 1)
+    assert records[0].category == "Drinks"
 
 
 def test_parse_statement_csv_tab_delimited(tmp_path):
@@ -248,6 +251,20 @@ def test_parse_statement_csv_date_formats(tmp_path):
     assert len(records) == 2
     assert records[0].date == datetime(2023, 1, 2)
     assert records[1].date == datetime(2023, 1, 3)
+
+
+def test_parse_statement_csv_category_detection(tmp_path):
+    csv_text = (
+        "date,description,amount,category\n"
+        "2023-01-01,Gym,10,Health"
+    )
+    f = tmp_path / "cat.csv"
+    f.write_text(csv_text)
+    from budget_tool import parse_statement_csv
+
+    records = parse_statement_csv(f)
+    assert len(records) == 1
+    assert records[0].category == "Health"
 
 
 def test_find_recurring_expenses():

--- a/webapp.py
+++ b/webapp.py
@@ -321,8 +321,8 @@ def auto_scan():
             statements.append(budget_tool.parse_statement_csv(data))
         found = budget_tool.find_recurring_expenses(statements, day_window=2)
         existing = {d for d, _ in budget_tool.get_monthly_expenses()}
-        results = [(d, a) for d, a in found if d not in existing]
-        recurring_names = {d for d, _ in found}
+        results = [(d, a, c) for d, a, c in found if d not in existing]
+        recurring_names = {d for d, _, _ in found}
         for month in statements:
             for r in month:
                 if r.amount < 0 and r.description not in recurring_names and r.description not in existing:
@@ -334,8 +334,9 @@ def auto_scan():
             if desc is None:
                 break
             amt = request.form.get(f"amt_{i}", type=float)
+            cat = request.form.get(f"cat_{i}") or "Misc"
             if request.form.get(f"add_{i}") == "on":
-                budget_tool.add_monthly_expense(desc, amt)
+                budget_tool.add_monthly_expense(desc, amt, cat)
             i += 1
         results = []
     expenses = budget_tool.get_monthly_expenses()


### PR DESCRIPTION
## Summary
- parse categories from uploaded CSV statements
- include optional category in `TransactionRecord`
- return category from `find_recurring_expenses`
- allow Auto Scan to store expenses with detected categories
- show category column in the Auto Scan results table
- document CSV category support
- test CSV category parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846accbd0fc8329b86085ddbad8d87a