### PR TITLE
Add REST API, encrypted DB and chart updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,20 @@ secure random value when deploying. Firebase authentication also requires the
 ### Supported statement formats
 
 Uploaded CSV statements may be comma or tab delimited. The parser will automatically detect the delimiter. Dates may be in ISO format (`YYYY-MM-DD`), compact form (`YYYYMMDD`) or U.S. style (`MM/DD/YYYY`). The first row should include `Date`, `Description` and `Amount` columns. If a column containing the word `Category` (e.g. `Transaction Category`) is present it will be used to assign categories when saving monthly expenses.
+
+## REST API
+A REST API is available for mobile or third-party clients. When running
+`webapp.py`, requests may be made to `/api/*` endpoints using a Bearer token
+in the `Authorization` header. Supported resources include categories,
+transactions, accounts and goals.
+
+## Encrypted Databases
+Set the `SQLITE_KEY` environment variable to create an encrypted database
+using SQLCipher. Install the optional `pysqlcipher3` package and run:
+
+```bash
+SQLITE_KEY=mysecret python3 budget_tool.py init
+```
+
+All subsequent CLI and web operations will open the database with the
+same key.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,127 @@
+from flask import Blueprint, request, jsonify, g
+import budget_tool
+from functools import wraps
+
+bp = Blueprint('api', __name__)
+
+
+def token_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        auth = request.headers.get('Authorization', '')
+        if not auth.startswith('Bearer '):
+            return jsonify({'error': 'Unauthorized'}), 401
+        token = auth.split(' ', 1)[1]
+        user = budget_tool.login_user(token)
+        if not user:
+            return jsonify({'error': 'Unauthorized'}), 401
+        g.current_user = user
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@bp.route('/categories', methods=['GET', 'POST'])
+@token_required
+def categories():
+    if request.method == 'GET':
+        conn = budget_tool.get_connection()
+        cur = conn.execute('SELECT name FROM categories ORDER BY name')
+        names = [r[0] for r in cur.fetchall()]
+        conn.close()
+        return jsonify(names)
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'name required'}), 400
+    budget_tool.add_category(name)
+    return jsonify({'status': 'ok'}), 201
+
+
+@bp.route('/accounts', methods=['GET', 'POST'])
+@token_required
+def accounts():
+    if request.method == 'GET':
+        rows = budget_tool.get_all_accounts()
+        accounts = []
+        for r in rows:
+            accounts.append({
+                'name': r['name'],
+                'balance': r['balance'],
+                'payment': r['monthly_payment'],
+                'type': r['type'],
+            })
+        return jsonify(accounts)
+    data = request.get_json() or {}
+    try:
+        name = data['name']
+        balance = float(data['balance'])
+    except Exception:
+        return jsonify({'error': 'invalid data'}), 400
+    payment = float(data.get('payment', 0))
+    acct_type = data.get('type', 'Other')
+    budget_tool.set_account(name, balance, payment, acct_type)
+    return jsonify({'status': 'ok'}), 201
+
+
+@bp.route('/transactions', methods=['GET', 'POST'])
+@token_required
+def transactions():
+    user = g.current_user
+    if request.method == 'GET':
+        limit = request.args.get('limit', default=50, type=int)
+        conn = budget_tool.get_connection()
+        user_id = budget_tool.get_user_id(conn, user)
+        cur = conn.execute(
+            """
+            SELECT t.id, c.name, t.amount, t.type, t.description,
+                   t.item_name, t.created_at
+            FROM transactions t
+            JOIN categories c ON t.category_id = c.id
+            WHERE t.user_id=?
+            ORDER BY t.created_at DESC
+            LIMIT ?
+            """,
+            (user_id, limit),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        data = [
+            {
+                'id': r['id'],
+                'category': r['name'],
+                'amount': r['amount'],
+                'type': r['type'],
+                'description': r['description'],
+                'item_name': r['item_name'],
+                'created_at': r['created_at'],
+            }
+            for r in rows
+        ]
+        return jsonify(data)
+    data = request.get_json() or {}
+    try:
+        category = data['category']
+        amount = float(data['amount'])
+        ttype = data['type']
+    except Exception:
+        return jsonify({'error': 'invalid data'}), 400
+    budget_tool.add_transaction(category, amount, ttype, data.get('description'), data.get('item_name'), user=user)
+    return jsonify({'status': 'ok'}), 201
+
+
+@bp.route('/goals', methods=['GET', 'POST'])
+@token_required
+def goals():
+    user = g.current_user
+    if request.method == 'GET':
+        rows = budget_tool.get_goal_status(user)
+        data = [{'category': r[0], 'goal': r[1], 'spent': r[2]} for r in rows]
+        return jsonify(data)
+    data = request.get_json() or {}
+    try:
+        category = data['category']
+        amount = float(data['amount'])
+    except Exception:
+        return jsonify({'error': 'invalid data'}), 400
+    budget_tool.set_goal(category, amount, user)
+    return jsonify({'status': 'ok'}), 201

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,7 +6,7 @@
     <div class="card bg-success text-white">
       <div class="card-body">
         <h5 class="card-title">Income</h5>
-        <p class="card-text">{{ income|fmt }}</p>
+        <p class="card-text" id="income">0.00</p>
       </div>
     </div>
   </div>
@@ -14,7 +14,7 @@
     <div class="card bg-danger text-white">
       <div class="card-body">
         <h5 class="card-title">Expense</h5>
-        <p class="card-text">{{ expense|fmt }}</p>
+        <p class="card-text" id="expense">0.00</p>
       </div>
     </div>
   </div>
@@ -22,7 +22,7 @@
     <div class="card bg-primary text-white">
       <div class="card-body">
         <h5 class="card-title">Net Balance</h5>
-        <p class="card-text">{{ net|fmt }}</p>
+        <p class="card-text" id="net">0.00</p>
       </div>
     </div>
   </div>
@@ -39,29 +39,30 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
-const catData = {{ cat_data|tojson }};
-const acctData = {{ account_data|tojson }};
-new Chart(document.getElementById('catChart').getContext('2d'), {
-  type: 'bar',
-  data: {
-    labels: catData.map(r => r[0]),
-    datasets: [{label: 'Spent', data: catData.map(r => r[1]), backgroundColor: '#007bff'}]
-  },
-  options: {
-    plugins: {legend: {display: false}, tooltip: {enabled: true}},
-    animation: {duration: 700}
-  }
-});
-new Chart(document.getElementById('acctChart').getContext('2d'), {
-  type: 'pie',
-  data: {
-    labels: acctData.map(r => r[0]),
-    datasets: [{data: acctData.map(r => r[1])}]
-  },
-  options: {
-    plugins: {tooltip: {enabled: true}},
-    animation: {duration: 700}
-  }
-});
+fetch('/dashboard-data')
+  .then(r => r.json())
+  .then(data => {
+    document.getElementById('income').textContent =
+      data.income.toLocaleString(undefined,{minimumFractionDigits:2});
+    document.getElementById('expense').textContent =
+      data.expense.toLocaleString(undefined,{minimumFractionDigits:2});
+    document.getElementById('net').textContent =
+      data.net.toLocaleString(undefined,{minimumFractionDigits:2});
+    const catData = data.categories;
+    const acctData = data.accounts;
+    new Chart(document.getElementById('catChart').getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: catData.map(r => r[0]),
+        datasets: [{label: 'Spent', data: catData.map(r => r[1]), backgroundColor: '#007bff'}]
+      },
+      options: {plugins: {legend:{display:false}, tooltip:{enabled:true}}, animation:{duration:700}}
+    });
+    new Chart(document.getElementById('acctChart').getContext('2d'), {
+      type: 'pie',
+      data: {labels: acctData.map(r => r[0]), datasets: [{data: acctData.map(r => r[1])}]},
+      options: {plugins:{tooltip:{enabled:true}}, animation:{duration:700}}
+    });
+  });
 </script>
 {% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import budget_tool
+import webapp
+import api
+
+
+def setup_client(tmp_path, monkeypatch):
+    budget_tool.DB_FILE = tmp_path / "budget.db"
+    webapp.setup_db()
+    monkeypatch.setattr(budget_tool, "login_user", lambda t: "tester")
+    budget_tool.add_user("tester")
+    client = webapp.app.test_client()
+    return client
+
+
+def auth_hdr():
+    return {"Authorization": "Bearer x"}
+
+
+def test_categories_api(tmp_path, monkeypatch):
+    client = setup_client(tmp_path, monkeypatch)
+    resp = client.post("/api/categories", json={"name": "Food"}, headers=auth_hdr())
+    assert resp.status_code == 201
+    resp = client.get("/api/categories", headers=auth_hdr())
+    assert resp.get_json() == ["Food"]
+
+
+def test_accounts_api(tmp_path, monkeypatch):
+    client = setup_client(tmp_path, monkeypatch)
+    resp = client.post(
+        "/api/accounts",
+        json={"name": "Bank", "balance": 100, "payment": 0, "type": "Bank"},
+        headers=auth_hdr(),
+    )
+    assert resp.status_code == 201
+    resp = client.get("/api/accounts", headers=auth_hdr())
+    data = resp.get_json()
+    assert data and data[0]["name"] == "Bank"
+
+
+def test_transactions_api(tmp_path, monkeypatch):
+    client = setup_client(tmp_path, monkeypatch)
+    client.post("/api/categories", json={"name": "Misc"}, headers=auth_hdr())
+    resp = client.post(
+        "/api/transactions",
+        json={"category": "Misc", "amount": 5, "type": "expense"},
+        headers=auth_hdr(),
+    )
+    assert resp.status_code == 201
+    resp = client.get("/api/transactions", headers=auth_hdr())
+    data = resp.get_json()
+    assert data and data[0]["amount"] == 5
+
+
+def test_goals_api(tmp_path, monkeypatch):
+    client = setup_client(tmp_path, monkeypatch)
+    client.post("/api/categories", json={"name": "Food"}, headers=auth_hdr())
+    resp = client.post(
+        "/api/goals",
+        json={"category": "Food", "amount": 50},
+        headers=auth_hdr(),
+    )
+    assert resp.status_code == 201
+    resp = client.get("/api/goals", headers=auth_hdr())
+    data = resp.get_json()
+    assert data and data[0]["goal"] == 50

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import sqlite3
+import os
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import budget_tool
+
+try:
+    import pysqlcipher3
+    HAS_SQLCIPHER = True
+except Exception:
+    HAS_SQLCIPHER = False
+
+
+@pytest.mark.skipif(not HAS_SQLCIPHER, reason="pysqlcipher3 not installed")
+def test_encrypted_database(tmp_path, monkeypatch):
+    monkeypatch.setenv("SQLITE_KEY", "secret")
+    budget_tool.DB_FILE = tmp_path / "enc.db"
+    budget_tool.init_db()
+    budget_tool.add_category("Food")
+    conn = budget_tool.get_connection()
+    conn.execute("SELECT name FROM categories")
+    conn.close()
+    with pytest.raises(sqlite3.DatabaseError):
+        sqlite3.connect(budget_tool.DB_FILE).execute("SELECT 1")

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -347,3 +347,15 @@ def test_csrf_required(tmp_path):
     resp = client.post("/add-category", data={"name": "X", "csrf_token": token})
     assert resp.status_code == 302
 
+
+def test_dashboard_data(tmp_path, monkeypatch):
+    client = setup_app(tmp_path)
+    budget_tool.add_category("Food")
+    budget_tool.add_transaction("Food", 10, "expense")
+    login(client, monkeypatch)
+    resp = client.get("/dashboard-data")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "categories" in data
+    assert data["categories"][0][0] == "Food"
+


### PR DESCRIPTION
## Summary
- register API blueprint and deliver dashboard data as JSON
- use SQLCipher when `SQLITE_KEY` environment variable is set
- fetch dashboard chart info from `/dashboard-data`
- implement REST API with token-based auth
- expand tests to cover API and encryption features

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847eaec9b2883298881be68c9a089a3