### PR TITLE
Add migration setup and security stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The web server reads `FLASK_SECRET_KEY` to sign session cookies. Set this to a
 secure random value when deploying. Firebase authentication also requires the
 `FIREBASE_CREDENTIALS` variable pointing to your service account JSON file and
 `AUTH_ENABLED=1` to enable login.
+`SESSION_COOKIE_SECURE` and `SESSION_COOKIE_SAMESITE` may be set to harden
+cookies in production. Use `DATABASE_URL` to point to a remote database
+instead of the local SQLite file.
 
 ### Supported statement formats
 
@@ -111,3 +114,13 @@ SQLITE_KEY=mysecret python3 budget_tool.py init
 
 All subsequent CLI and web operations will open the database with the
 same key.
+
+## Database Migrations
+Database schema changes are managed with Alembic. Initialize the migration
+environment and apply migrations using:
+
+```bash
+alembic upgrade head
+```
+
+Set `DATABASE_URL` to run migrations against a remote database.

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,6 @@
 
 - Integrate Plaid API to pull bank transactions for premium users.
 - Enforce API rate limits and billing management for subscriptions.
+- Determine how to bill subscribers (Stripe, PayPal, etc.).
+- Host the web app on a production website for desktop users.
+- Implement OAuth login flows and CSRF protection tests.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = env:DATABASE_URL
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import os
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+config = context.config
+fileConfig(config.config_file_name)
+
+DB_URL = os.environ.get("DATABASE_URL", f"sqlite:///" + os.environ.get("BUDGET_DB", "budget.db"))
+config.set_main_option("sqlalchemy.url", DB_URL)
+
+def run_migrations_offline():
+    context.configure(url=config.get_main_option("sqlalchemy.url"), literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,108 @@
+"""initial schema"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                auth_uid TEXT UNIQUE
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS transactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                amount REAL NOT NULL,
+                type TEXT CHECK(type IN ('income','expense')) NOT NULL,
+                description TEXT,
+                item_name TEXT,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(category_id) REFERENCES categories(id),
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS goals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                category_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                amount REAL NOT NULL,
+                UNIQUE(category_id, user_id),
+                FOREIGN KEY(category_id) REFERENCES categories(id),
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS accounts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                balance REAL NOT NULL,
+                monthly_payment REAL DEFAULT 0,
+                type TEXT DEFAULT 'Other',
+                apr REAL DEFAULT 0,
+                escrow REAL DEFAULT 0,
+                insurance REAL DEFAULT 0,
+                tax REAL DEFAULT 0
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS monthly_expenses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT UNIQUE NOT NULL,
+                amount REAL NOT NULL
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS monthly_incomes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT UNIQUE NOT NULL,
+                amount REAL NOT NULL
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS one_time_expenses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                amount REAL NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(description, created_at)
+            )"""
+    )
+    op.execute(
+        """CREATE TABLE IF NOT EXISTS subscriptions (
+                user_id INTEGER PRIMARY KEY,
+                tier TEXT NOT NULL DEFAULT 'free' CHECK(tier IN ('free','premium')),
+                start_date TEXT NOT NULL,
+                last_sync TEXT,
+                FOREIGN KEY(user_id) REFERENCES users(id)
+            )"""
+    )
+
+
+def downgrade():
+    op.execute("DROP TABLE IF EXISTS subscriptions")
+    op.execute("DROP TABLE IF EXISTS one_time_expenses")
+    op.execute("DROP TABLE IF EXISTS monthly_incomes")
+    op.execute("DROP TABLE IF EXISTS monthly_expenses")
+    op.execute("DROP TABLE IF EXISTS accounts")
+    op.execute("DROP TABLE IF EXISTS goals")
+    op.execute("DROP TABLE IF EXISTS transactions")
+    op.execute("DROP TABLE IF EXISTS categories")
+    op.execute("DROP TABLE IF EXISTS users")
+

--- a/auth.py
+++ b/auth.py
@@ -27,3 +27,9 @@ def init_firebase():
 def verify_id_token(id_token: str) -> dict:
     init_firebase()
     return auth.verify_id_token(id_token)
+
+
+def oauth_login(provider: str) -> dict | None:
+    """Placeholder for future OAuth login support."""
+    # TODO: implement OAuth flows for providers like Google or Facebook
+    raise NotImplementedError("OAuth login not yet implemented")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ firebase-admin
 
 Flask
 Flask-WTF
+SQLAlchemy
+alembic
+psycopg2-binary

--- a/webapp.py
+++ b/webapp.py
@@ -18,6 +18,12 @@ from flask_wtf.csrf import CSRFProtect
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY", "devkey")
+app.config["SESSION_COOKIE_SECURE"] = (
+    os.environ.get("SESSION_COOKIE_SECURE", "0") == "1"
+)
+app.config["SESSION_COOKIE_SAMESITE"] = os.environ.get(
+    "SESSION_COOKIE_SAMESITE", "Lax"
+)
 csrf = CSRFProtect(app)
 AUTH_ENABLED = os.environ.get("AUTH_ENABLED", "0") == "1"
 app.register_blueprint(api_bp, url_prefix="/api")


### PR DESCRIPTION
## Summary
- note billing & OAuth plans in TODO
- support secure cookie options and stub OAuth login
- allow remote database via `DATABASE_URL`
- add Alembic config with initial migration
- document new environment variables and migration usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ef8f0cb08329a98bdd16ed379a38