### PR TITLE
Add budget slider page

### DIFF
--- a/templates/budget.html
+++ b/templates/budget.html
@@ -1,0 +1,60 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Budget</h1>
+<div class="mb-3">
+  <label for="acctSelect" class="form-label">Account</label>
+  <select id="acctSelect" class="form-select">
+  {% for a in accounts %}
+    <option value="{{ loop.index0 }}">{{ a.name }}</option>
+  {% else %}
+    <option disabled>No accounts</option>
+  {% endfor %}
+  </select>
+</div>
+<div class="mb-3">
+  <label for="extraRange" class="form-label">Extra Payment: $<span id="extraVal">0</span></label>
+  <input type="range" class="form-range" id="extraRange" min="0" max="{{ net }}" step="1" value="0">
+</div>
+<p>Left over each month: $<span id="leftover">{{ net|fmt }}</span></p>
+<p>Months to payoff: <span id="months">{{ accounts[0].months if accounts else 'n/a' }}</span></p>
+<script>
+const net = {{ net }};
+const accounts = {{ accounts | tojson }};
+function monthsToPayoff(balance, payment, apr, esc, ins, tax){
+  const principal = payment - esc - ins - tax;
+  if(principal <= 0) return null;
+  if(apr <= 0){
+    return Math.ceil((balance + principal - 1) / principal);
+  }
+  let r = apr/12/100;
+  let months = 0;
+  let prev = balance;
+  while(balance > 0 && months < 10000){
+    const interest = balance * r;
+    balance = balance + interest - principal;
+    months++;
+    if(balance >= prev) return null;
+    prev = balance;
+  }
+  return months;
+}
+function update(){
+  const idx = document.getElementById('acctSelect').value;
+  const extra = parseFloat(document.getElementById('extraRange').value);
+  document.getElementById('extraVal').textContent = extra.toLocaleString(undefined,{minimumFractionDigits:2});
+  const left = net - extra;
+  document.getElementById('leftover').textContent = left.toLocaleString(undefined,{minimumFractionDigits:2});
+  const acc = accounts[idx];
+  if(!acc){
+    document.getElementById('months').textContent = 'n/a';
+    return;
+  }
+  const m = monthsToPayoff(acc.balance, acc.payment + extra, acc.apr, acc.escrow, acc.insurance, acc.tax);
+  document.getElementById('months').textContent = m === null ? 'n/a' : m;
+}
+['acctSelect','extraRange'].forEach(id=>{
+  document.getElementById(id).addEventListener('input', update);
+});
+document.addEventListener('DOMContentLoaded', update);
+</script>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -23,6 +23,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('history') }}">History</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('auto_scan') }}">Auto Scan</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('forecast_route') }}">Forecast</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('budget_page') }}">Budget</a></li>
         </ul>
         <div class="d-flex align-items-center gap-2">
           <select id="theme-select" class="form-select form-select-sm">

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -214,6 +214,13 @@ def test_nav_contains_auto_scan(tmp_path):
     assert b"/auto-scan" in resp.data
 
 
+def test_nav_contains_budget(tmp_path):
+    client = setup_app(tmp_path)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"/budget" in resp.data
+
+
 def test_protected_requires_login(tmp_path):
     client = setup_app(tmp_path)
     resp = client.get("/manage")
@@ -358,4 +365,13 @@ def test_dashboard_data(tmp_path, monkeypatch):
     data = resp.get_json()
     assert "categories" in data
     assert data["categories"][0][0] == "Food"
+
+
+def test_budget_route(tmp_path, monkeypatch):
+    client = setup_app(tmp_path)
+    budget_tool.set_account("Loan", 1000, 50, "Loan")
+    login(client, monkeypatch)
+    resp = client.get("/budget")
+    assert resp.status_code == 200
+    assert b"Budget" in resp.data
 

--- a/webapp.py
+++ b/webapp.py
@@ -97,6 +97,10 @@ def get_accounts():
                 "balance": r["balance"],
                 "payment": r["monthly_payment"],
                 "type": r["type"],
+                "apr": r["apr"],
+                "escrow": r["escrow"],
+                "insurance": r["insurance"],
+                "tax": r["tax"],
                 "months": months,
                 "increase": increase,
             }
@@ -319,6 +323,19 @@ def forecast_route():
         debts=debts,
         months=months,
         label=label,
+    )
+
+
+@app.route("/budget")
+@require_login
+def budget_page():
+    """Interactive budgeting tool with payment slider."""
+    income, expense, net = get_totals()
+    accounts, _ = get_accounts()
+    return render_template(
+        "budget.html",
+        accounts=accounts,
+        net=net,
     )
 
 


### PR DESCRIPTION
## Summary
- extend `get_accounts` to expose APR/escrow/insurance/tax
- add `/budget` route
- add Budget link to nav
- implement interactive slider template
- test new navigation and budget page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f43f7d608329a70634b1b37ac343