### PR TITLE
Add leftover warning icon

### DIFF
--- a/templates/budget.html
+++ b/templates/budget.html
@@ -1,7 +1,13 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h1>Budget</h1>
-<p>Left over each month: $<span id="leftover" class="{{ leftover_class }}">{{ leftover|fmt }}</span></p>
+<p>Left over each month: $<span id="leftover" class="{{ leftover_class }}">{{ leftover|fmt }}</span>
+  <span id="leftover-icon" class="{{ leftover_class }} ms-1" data-bs-toggle="tooltip"
+        title="Caution: less than 20% left over"
+        style="{% if leftover_warning %}display:inline{% else %}display:none{% endif %}">
+    <i class="bi-exclamation-circle-fill"></i>
+  </span>
+</p>
 {% for a in accounts %}
 <div class="card mb-3 p-3">
   <h5 class="card-title">{{ a.name }}</h5>
@@ -61,16 +67,29 @@ function update(){
   });
   const left = net - totalExtra;
   const leftElem = document.getElementById('leftover');
+  const icon = document.getElementById('leftover-icon');
   leftElem.textContent =
     left.toLocaleString(undefined,{minimumFractionDigits:2});
   leftElem.classList.remove('text-warning', 'text-danger');
+  icon.classList.remove('text-warning', 'text-danger');
   if(left <= warn2){
     leftElem.classList.add('text-danger');
+    icon.classList.add('text-danger');
   }else if(left <= warn1){
     leftElem.classList.add('text-warning');
+    icon.classList.add('text-warning');
+  }
+  if(left <= warn1){
+    icon.style.display = 'inline';
+  }else{
+    icon.style.display = 'none';
   }
 }
 document.querySelectorAll('.extra-range').forEach(el=>{ el.addEventListener('input', update); });
-document.addEventListener('DOMContentLoaded', update);
+document.addEventListener('DOMContentLoaded', () => {
+  update();
+  const trigger = document.getElementById('leftover-icon');
+  if(trigger){ new bootstrap.Tooltip(trigger); }
+});
 </script>
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <link id="theme-link" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/cyborg/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link id="font-link" href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -462,8 +462,12 @@ def test_budget_leftover_classes(tmp_path, monkeypatch):
     login(client, monkeypatch)
     resp = client.get("/budget")
     assert b'class="text-warning"' in resp.data
+    assert b'id="leftover-icon"' in resp.data
+    assert b'display:inline' in resp.data
     # set extra to trigger danger
     budget_tool.add_monthly_expense("Extra Payment - Loan", 950, "Extra Payment")
     resp = client.get("/budget")
     assert b'class="text-danger"' in resp.data
+    assert b'id="leftover-icon"' in resp.data
+    assert b'display:inline' in resp.data
 

--- a/webapp.py
+++ b/webapp.py
@@ -354,12 +354,14 @@ def budget_page():
         leftover_class = "text-warning"
     else:
         leftover_class = ""
+    leftover_warning = leftover <= warn1
     return render_template(
         "budget.html",
         accounts=accounts,
         net=base_net,
         leftover=leftover,
         leftover_class=leftover_class,
+        leftover_warning=leftover_warning,
     )
 
 


### PR DESCRIPTION
## Summary
- show an exclamation icon near monthly leftover when funds drop below 20%
- include Bootstrap Icons for the new icon
- update JS logic to toggle the icon and initialize tooltip
- extend tests to ensure the icon appears when expected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848033777b083298722d5120ec0ef88